### PR TITLE
refactor: replace obsolete if-let with if-let*

### DIFF
--- a/dsh-emacs-markdown.el
+++ b/dsh-emacs-markdown.el
@@ -1988,7 +1988,7 @@ fence (e.g. \"python\", \"elisp\").  When the resolved mode is
 loadable, CODE is fontified in a temporary buffer and returned
 with face properties applied.  Otherwise CODE is returned
 unchanged."
-  (if-let ((mode (dsh-emacs-markdown--resolve-lang-mode lang))
+  (if-let* ((mode (dsh-emacs-markdown--resolve-lang-mode lang))
            ((fboundp mode)))
       (with-temp-buffer
         (insert code)


### PR DESCRIPTION
Replace the obsolete `if-let` macro with `if-let*` in `dsh-emacs-markdown.el` (line 1991), removing the byte-compile warning:

> Warning: 'if-let' is an obsolete macro (as of 31.1); use 'if-let*' instead.

Behavior is unchanged. Verified with the package's checks: paren balance passes and `batch-byte-compile` emits no warnings.