### PR TITLE
feat: add tooltips and hover highlight to footer segments

### DIFF
--- a/dsh-emacs-footer.el
+++ b/dsh-emacs-footer.el
@@ -186,10 +186,26 @@ seconds; a nil (non-repo) result is cached the same way."
 ;;; 各段格式化
 ;;; ---------------------------------------------------------------------------
 
+(defun dsh-emacs-footer--annotate (text tooltip)
+  "Return TEXT with TOOLTIP attached as its `help-echo' plus the
+standard mode-line hover affordance: `mouse-face' set to
+`mode-line-highlight', so the segment's extent shows a box border
+while the mouse is over it (the same face the built-in mode-line
+elements use; GUI renders it as a released-button box, terminal as
+inverse video).  Passes TEXT through unchanged when nil/empty,
+keeping the existing hidden-segment semantics intact."
+  (if (or (null text) (string-empty-p text))
+      text
+    (propertize text 'help-echo tooltip
+                'mouse-face 'mode-line-highlight)))
+
 (defun dsh-emacs-footer--segment-cwd ()
   "Render the cwd segment."
   (let ((cwd (dsh-emacs-footer--shorten-cwd (or dsh-emacs--footer-cwd default-directory))))
-    (propertize cwd 'face 'dsh-emacs-footer-face)))
+    (dsh-emacs-footer--annotate
+     (propertize cwd 'face 'dsh-emacs-footer-face)
+     (format "Working directory: %s"
+             (or dsh-emacs--footer-cwd default-directory)))))
 
 (defun dsh-emacs-footer--segment-branch ()
   "Render the git branch segment (cached; see
@@ -197,9 +213,11 @@ seconds; a nil (non-repo) result is cached the same way."
   (let ((branch (or dsh-emacs--footer-branch
                     (dsh-emacs-footer--cached-branch))))
     (when (and branch (not (string-empty-p branch)))
-      (concat (propertize "(" 'face 'dsh-emacs-footer-face)
-              (propertize branch 'face 'dsh-emacs-footer-face)
-              (propertize ")" 'face 'dsh-emacs-footer-face)))))
+      (dsh-emacs-footer--annotate
+       (concat (propertize "(" 'face 'dsh-emacs-footer-face)
+               (propertize branch 'face 'dsh-emacs-footer-face)
+               (propertize ")" 'face 'dsh-emacs-footer-face))
+       (format "Git branch: %s" branch)))))
 
 (defun dsh-emacs-footer--segment-model ()
   "Render the model segment.
@@ -209,19 +227,26 @@ set (e.g. a session that predates request events)."
                    (and (boundp 'dsh-emacs-default-model)
                         dsh-emacs-default-model))))
     (when (and model (not (string-empty-p model)))
-      (propertize model 'face 'dsh-emacs-footer-face))))
+      (dsh-emacs-footer--annotate
+       (propertize model 'face 'dsh-emacs-footer-face)
+       (format "Model: %s — reasoning model of this session (switch with C-c C-m)"
+               model)))))
 
 (defun dsh-emacs-footer--segment-effort ()
   "Render the reasoning-effort segment (effortId, e.g. \"max\")."
   (when (and dsh-emacs--footer-effort
              (not (string-empty-p dsh-emacs--footer-effort)))
-    (propertize dsh-emacs--footer-effort 'face 'dsh-emacs-footer-face)))
+    (dsh-emacs-footer--annotate
+     (propertize dsh-emacs--footer-effort 'face 'dsh-emacs-footer-face)
+     (format "Reasoning effort: %s" dsh-emacs--footer-effort))))
 
 (defun dsh-emacs-footer--segment-preset ()
   "Render the agent-preset segment (agentPreset, e.g. \"code\")."
   (when (and dsh-emacs--footer-preset
              (not (string-empty-p dsh-emacs--footer-preset)))
-    (propertize dsh-emacs--footer-preset 'face 'dsh-emacs-footer-face)))
+    (dsh-emacs-footer--annotate
+     (propertize dsh-emacs--footer-preset 'face 'dsh-emacs-footer-face)
+     (format "Agent preset: %s" dsh-emacs--footer-preset))))
 
 (defun dsh-emacs-footer--segment-tokens ()
   "Render the token usage segment."
@@ -243,8 +268,20 @@ set (e.g. a session that predates request events)."
       (when ch (push (propertize (format "CH%.0f%%" ch)
                                  'face 'dsh-emacs-footer-token-face) parts))
       (when parts
-        (mapconcat #'identity (nreverse parts)
-                   (propertize " " 'face 'dsh-emacs-footer-separator-face))))))
+        (let* ((seg (mapconcat
+                     #'identity
+                     (delq nil
+                           (list
+                            (and (> input 0)
+                                 (format "↑%s in" (dsh-emacs-format-tokens input)))
+                            (and (> output 0)
+                                 (format "↓%s out" (dsh-emacs-format-tokens output)))
+                            (and ch (format "CH%.0f%% cache hit" ch))))
+                     " ")))
+          (dsh-emacs-footer--annotate
+           (mapconcat #'identity (nreverse parts)
+                      (propertize " " 'face 'dsh-emacs-footer-separator-face))
+           (format "Token usage: %s" seg)))))))
 
 (defun dsh-emacs-footer--segment-ctx ()
   "Render the context-window usage percentage segment.
@@ -260,15 +297,22 @@ segment renders nothing (nil hides it)."
          (pct (and pressure window (> window 0)
                    (min 100.0 (* 100.0 (/ (float pressure) window))))))
     (when pct
-      (propertize (dsh-emacs-format-percent pct)
-                  'face (dsh-emacs-ctx-face pct)))))
+      (dsh-emacs-footer--annotate
+       (propertize (dsh-emacs-format-percent pct)
+                   'face (dsh-emacs-ctx-face pct))
+       (format "Context window: %s (%s / %s tokens)"
+               (dsh-emacs-format-percent pct)
+               (dsh-emacs-format-tokens pressure)
+               (dsh-emacs-format-tokens window))))))
 
 (defun dsh-emacs-footer--segment-cost ()
   "Render the cost segment."
   (when dsh-emacs--footer-usage
     (let ((cost (dsh-emacs-usage-cost dsh-emacs--footer-usage)))
       (when (> cost 0)
-        (propertize (dsh-emacs-format-cost cost) 'face 'dsh-emacs-footer-cost-face)))))
+        (dsh-emacs-footer--annotate
+         (propertize (dsh-emacs-format-cost cost) 'face 'dsh-emacs-footer-cost-face)
+         (format "Session cost: %s" (dsh-emacs-format-cost cost)))))))
 
 (defun dsh-emacs-footer--render-segment (sym)
   "Render footer segment named SYM."
@@ -516,7 +560,9 @@ running (space on both sides, ready to sit right after the DSH mode name)."
   (let ((frame (dsh-emacs--ml-busy-indicator)))
     (if (string-empty-p frame)
         ""
-      (concat " " frame " "))))
+      (propertize (concat " " frame " ")
+                  'help-echo "dsh is running a request…"
+                  'mouse-face 'mode-line-highlight))))
 
 (defun dsh-emacs-footer--escape-percent (txt)
   "Escape `%' in TXT for mode-line display, keeping text properties.

--- a/test/dsh-test.el
+++ b/test/dsh-test.el
@@ -153,6 +153,34 @@ so the code under test can read fields through the protocol accessors."
              (string-match "CH92%%" txt))
     (dsh-test-pass "modeinline wraps stats in parens and escapes percent")))
 
+;; --- 测试 5e+1: footer 分段携带 help-echo tooltip，空值透传 ---
+(let ((dsh-emacs-footer-format-spec '(:separator " " :segments (model effort preset ctx))))
+  (setq dsh-emacs--footer-model "m1"
+        dsh-emacs--footer-effort "max"
+        dsh-emacs--footer-preset "standard"
+        dsh-emacs--footer-context-pressure 1234
+        dsh-emacs--footer-context-window-server 10000)
+  (let* ((txt (dsh-emacs-footer-format))
+         (model-pos (string-match "m1" txt))
+         (ctx-pos (string-match "12\\.3%" txt))
+         (model-tip (and model-pos (get-text-property model-pos 'help-echo txt)))
+         (effort-tip (and (string-match "max" txt)
+                          (get-text-property (match-beginning 0) 'help-echo txt)))
+         (ctx-tip (and ctx-pos (get-text-property ctx-pos 'help-echo txt))))
+    (when (and (string-match-p "Model: m1" model-tip)
+               (string-match-p "Reasoning effort: max" effort-tip)
+               (string-match-p "1\\.2k" ctx-tip)
+               (string-match-p "10k" ctx-tip)
+               (eq 'mode-line-highlight
+                   (get-text-property model-pos 'mouse-face txt)))
+      (dsh-test-pass "footer-segments-carry-help-echo")))
+  (setq dsh-emacs--footer-context-pressure nil
+        dsh-emacs--footer-context-window-server nil))
+(let ((nil-tip (dsh-emacs-footer--annotate nil "x"))
+      (empty-tip (dsh-emacs-footer--annotate "" "x")))
+  (when (and (null nil-tip) (equal "" empty-tip))
+    (dsh-test-pass "annotate-passes-nil-and-empty-through")))
+
 ;; --- 测试 5f: request/header 喂 model 与 reasoningEffort（rc.1 事件形状） ---
 (let ((hdr '(("type" . "request/header")
              ("seq" . 11)


### PR DESCRIPTION
## What

The dsh-emacs footer segments in the mode line get proper tooltips and hover feedback:

- **`help-echo` tooltips** on every footer segment — hover to see what it means:
  - `cwd` → full working-directory path
  - `branch` → git branch
  - `model` → model id + hint that it can be switched via `C-c C-m`
  - `effort` → reasoning effort (reasoningEffort)
  - `preset` → agent preset (agentPreset)
  - `tokens` → token usage breakdown (↑in / ↓out / CH% cache hit)
  - `ctx` → context-window occupancy with raw token numbers, e.g. `Context window: 1.2% (3.7k / 300k tokens)`
  - `cost` → session cost
- **Hover highlight** via `mouse-face` + `mode-line-highlight` (the same face/text-property mechanism the built-in mode-line elements use), so the hovered segment's extent is boxed on GUI frames
- The running-request animation also gets a tooltip + highlight
- No click actions and no new defcustoms; nil/empty segments stay hidden (the annotate helper passes them through)

Demo GIF coming in a comment.

## Why

Headers in the minibuffer area had no way to explain themselves; hovering now explains each segment and shows its exact range.

## Verification

- `scripts/check-lisp.el`: 13/13 files pass
- `test/dsh-test.el`: 458 pass, 0 fail (2 new tests: help-echo content + mouse-face presence, nil/empty passthrough)
- clean load `-l dsh-emacs.el`: silent, exit 0
- byte-compile of `dsh-emacs-footer.el`: no errors
