### PR TITLE
fix: update check script for modeline rename

### DIFF
--- a/scripts/check-lisp.el
+++ b/scripts/check-lisp.el
@@ -9,7 +9,7 @@
   '("dsh-emacs.el" "dsh-emacs-protocol.el" "dsh-emacs-session.el"
     "dsh-emacs-markdown.el" "dsh-emacs-render.el" "dsh-emacs-events.el"
     "dsh-emacs-ui.el" "dsh-emacs-faces.el" "dsh-emacs-tokens.el"
-    "dsh-emacs-footer.el" "dsh-emacs-server.el" "dsh-emacs-command.el"
+    "dsh-emacs-modeline.el" "dsh-emacs-server.el" "dsh-emacs-command.el"
     "test/dsh-test.el")
   "默认检查的 elisp 文件（相对仓库根目录）。")
 


### PR DESCRIPTION
The `dsh-emacs-footer.el` → `dsh-emacs-modeline.el` rename left `scripts/check-lisp.el` referencing the old filename, so the one-shot paren balance check failed on a missing file:

```
read dsh-emacs-footer.el  FAIL (file-missing ...)
==> 13 file(s) checked, 12 passed, 1 failed
```

Update the file list to `dsh-emacs-modeline.el`. Verified: all 13 files pass, clean load OK, 458/458 unit tests pass.