### PR TITLE
feat: queue and steer messages while a turn is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,36 @@ minor) and stay undated until the release is cut.
   `mode-line-highlight` mouse-face affordance.
 - **Contributor tooling**: `scripts/verify.sh` aggregates every
   machine-checkable verification step into a single exit-code gate.
+- **Queue and steer while a turn runs**: `C-c C-c` no longer only
+  interrupts a running turn — input is delivered per the new
+  `dsh-emacs-busy-enter-behavior` option (`queue` default, `steer`, or
+  `stop` for the old interrupt-only behavior): queued input runs as the
+  next turn automatically, steering wakes the running agent before its
+  next step, `C-u C-c C-c` flips queue and steer for one send, and with
+  an empty input the turn is still interrupted.  Interrupting explicitly
+  is `C-c C-b` (`dsh-emacs-interrupt-turn`).  The pending inbox mirrors
+  the server's `session/queue` frames: a `[Q2 S1]` mode-line indicator
+  (hidden when empty, mouse-1 opens the manager), transient echo-area
+  feedback on enqueue (`queued: …`), steer (`steering: …`)
+  and consumption (`running: …`), an input-prompt preview — a small
+  clock icon (SVG, tinted with the prompt color) followed by the next
+  message the host will send: after a steer the steered item leads the
+  hint (in-flight `steering` items reach the running agent before any
+  item queued for the next turn, so `next` follows that delivery
+  order); our own steer/delete/edit
+  RPCs apply to the mirror optimistically on success, so the hint and
+  mode-line refresh the instant the call succeeds, without waiting for
+  the confirming `session/queue` frame; prefix repaints are coalesced
+  per frame burst, so an item the host splices and instantly claims
+  never flashes the hint),
+  and `C-c C-q` (`dsh-emacs-list-queue`) managing the queue from a
+  minibuffer candidate list — vertico up/down highlights an item and the
+  single keys act on it directly, with no numbered selection step (`e`
+  edit, `s` steer, `d` delete, `RET` send now, `x` delete the whole
+  queue after confirmation); one `C-g` cancels.  All wire names verified
+  against
+  the dsh 0.1.1-rc.2 RPC table (`session.prompt` `mode`, new
+  `session.updateQueue`).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ and how a session lands in the right workspace:
          ("C-c C-a" . dsh-emacs-attach-file)))
 ```
 
-Common keys inside a chat: `C-c C-c` send — press again to interrupt —
-`C-c C-m` switch model, `C-c C-a` attach an image, `C-c C-r` refresh,
-`C-c C-s` switch session in this workspace (`C-c M-s` or `C-u C-c C-s`
-across all workspaces),
-`C-c C-f` toggle the mode-line stats, `TAB` complete `/name`. In the session list:
-`RET` open, `c` create, `w` workspace filter, `/` search, `g` refresh.
-Everything else is in the [manual](#documentation).
+Common keys inside a chat: `C-c C-c` send — while a turn is running it
+queues the input as the next turn (`dsh-emacs-busy-enter-behavior`; `C-u`
+steers instead) and with an empty input interrupts — `C-c C-b` interrupts
+explicitly, `C-c C-q` manages the pending queue (minibuffer list, keys
+act on the highlighted item; `x` deletes all), `C-c C-m` switch model, `C-c C-a` attach an image, `C-c C-r`
+refresh, `C-c C-s` switch session in this workspace (`C-c M-s` or
+`C-u C-c C-s` across all workspaces),
+`C-c C-f` toggle the mode-line stats, `TAB` complete `/name`. In the
+session list: `RET` open, `c` create, `w` workspace filter, `/` search,
+`g` refresh.  Everything else is in the [manual](#documentation).
 
 ## Server setup
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,7 @@ dsh-emacs/
 ├── dsh-emacs-render.el       # Event renderer (user/assistant/tool/thinking)
 ├── dsh-emacs-events.el       # Event stream: native WebSocket + reconnect
 ├── dsh-emacs-modeline.el       # Mode-line stats
+├── dsh-emacs-queue.el        # Pending-input queue mirror (queue/steer)
 ├── dsh-emacs-server.el       # Server bootstrap: probe / auto-start / install
 └── dsh-emacs-session.el      # Session list card view
 ```
@@ -59,13 +60,46 @@ directly, with no server-side changes required:
 | `session.list` | List sessions (including running status, title, cwd) |
 | `session.create` | Create a session |
 | `session.history` | Read event history (incremental, anchor-diffed rendering) |
-| `session.prompt` | Send a message (text and/or inline base64 image attachments) |
-| `session.cancel` | Interrupt the running turn (partial reply is kept) |
+| `session.prompt` | Send a message (`mode: "queue"` = next turn, `"steer"` = wake the running agent; text and/or inline base64 image attachments) |
+| `session.updateQueue` | Manage pending inbox items (`edit` text / `remove` / `steer` by itemId) |
+| `session.cancel` | Interrupt the running turn (partial reply is kept, inbox preserved) |
 | `session.fork` | Branch a session into a child inheriting its history |
 | `session.models` | List the routable model catalog for a session |
 | `session.selectModel` | Switch the session's model |
 | `session.rename` | Rename a session |
 | `workspace.archiveSession` | Archive a session (remove from its workspace view) |
+
+## Pending-input queue (`session/queue` frames)
+
+Input sent while a turn runs is delivered through the agent inbox:
+`queue` lands in next-turn (the next turn), `steer` in next-step (before
+the running agent's next step).  The host pushes the authoritative
+snapshot as `session/queue` mux frames — once per connection for sessions
+with pending items, and on every inbox splice thereafter — so
+`dsh-emacs-queue.el` only mirrors frames (no fetch RPC, no local drift).
+The wire item shape (`id`, `placement` = `queued`/`steering`/`context`,
+`message.content`) is normalized to `dsh-protocol-queue-item` in
+`dsh-emacs-protocol.el`.  The mirror drives the mode-line `[Qn Sm]`
+indicator, the echo-area feedback (enqueue / steer / consumption,
+diffed against the previous mirror, with locally-deleted ids suppressed),
+the input-prompt prefix — a small clock icon (SVG `currentColor`
+mapped to the prompt face's foreground, `[next: …] ` brackets as
+fallback when Emacs lacks SVG support) followed by the next message
+the host will send: the preview follows the host's delivery order, so
+an item steered into the running turn (`steering`, next-step, injected
+at the agent's next step) leads it ahead of items queued for the next
+turn (`queued`, next-turn); our own steer/delete/edit RPCs update the
+mirror optimistically on
+success, so the hint and mode-line refresh immediately without waiting
+for the confirming frame; prefix repaints are coalesced per frame burst
+(one zero-delay timer paints the settled mirror), so an item the host
+splices and instantly claims never flashes the hint),
+and the `C-c C-q` manager (a
+minibuffer candidate list whose single keys `e`/`s`/`d`/`RET` act on the
+highlighted item; `x` deletes the whole queue).  `context`
+items (host-injected next-step content) are mirrored but never counted,
+previewed, or listed; `steering` items count and list, and — as the
+next thing the host injects — head the preview.
 
 ## Event rendering flow
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -13,6 +13,7 @@ The most commonly used options, straight in your config:
 (setq dsh-emacs-default-preset "standard")         ; default agent preset for new sessions (nil = host default; "standard"/"minimal"/"code"/"cordis" or a user preset id)
 (setq dsh-emacs-model-group-format #(" %s " 0 4 (face vertico-group-title))) ; provider group-header format inside the model picker (nil = hide group titles)
 (setq dsh-emacs-input-history-length 50)           ; prompts kept for M-p / M-n recall
+(setq dsh-emacs-busy-enter-behavior 'queue)          ; what C-c C-c does while a turn runs: `queue` lines input up as the next turn (default), `steer` wakes the running agent before its next step, `stop` interrupts like before; `C-u C-c C-c` flips queue/steer for one send, an empty input always interrupts, and `C-c C-b` interrupts explicitly (C-c C-q manages the queue)
 (setq dsh-emacs-question-skip-key "s")       ; key that skips the current ask question inside the minibuffer chooser (nil = no shortcut; option-less free-text questions still skip on empty input)
 (setq dsh-emacs-ui-label-separator "·")            ; separator between Think/Tool title and its right-side summary ("" = plain gap)
 (setq dsh-emacs-tool-titles '(("pwsh" . "PowerShell"))) ; tool name -> display title overrides (icons stay per variant; unnamed tools get a humanized name, e.g. grep -> "Grep")

--- a/docs/modeline.md
+++ b/docs/modeline.md
@@ -63,6 +63,17 @@ preserved:
 The animation lights up when a message is sent and goes out at `turn/end`; it
 is cleaned up automatically when the event stream disconnects.
 
+### Pending-input queue indicator
+
+While messages are queued or steering, a `[Q2 S1]` indicator (queued /
+steering counts; zero-count placements are omitted) sits right after the
+running animation, colored with `dsh-emacs-modeline-queue-face` (amber) and
+clickable (`mouse-1` opens `dsh-emacs-list-queue`).  It is hidden when
+nothing is pending — including when the queue holds only host-injected
+`context` items, which are neither counted nor listed, matching dsh web's
+QueueDock.  The counts come from the `session/queue` mux frames mirrored by
+`dsh-emacs-queue.el`, so the segment is live without any polling.
+
 ### Why the branch segment is cached
 
 The branch segment has a 10-second TTL cache

--- a/dsh-emacs-events.el
+++ b/dsh-emacs-events.el
@@ -96,6 +96,7 @@
 (declare-function dsh-emacs-session--render "dsh-emacs-session" ())
 (declare-function dsh-emacs--normalize-archived "dsh-emacs" (archived))
 (declare-function dsh-emacs-modeline-set-context-snapshot "dsh-emacs-modeline" (pressure window))
+(declare-function dsh-emacs-queue-apply "dsh-emacs-queue" (chat process payload))
 (declare-function dsh-emacs-server--basic-auth-header "dsh-emacs-server" ())
 
 ;; Defined in dsh-emacs-modeline.el, which loads after this module.  Referenced
@@ -384,6 +385,16 @@ through the normal path once loading completes."
                ;; 模型，免去全量 session.list 拉取）。value 是投影的 wire
                ;; view：{projectedTokens, pressureTokens, contextWindow}。
                ;; 投影是 per-session 实时状态，不依赖 history 加载门控。
+               ;; host 推送的收件箱快照帧：会话排队/引导输入的权威镜像
+               ;; （每次 inbox splice 全量推送；连接建立时对有积压的会话
+               ;; 也推一次）。与投影一样是 per-session 实时状态，不依赖
+               ;; history 加载门控——首个连接快照正是打开会话时获取积压
+               ;; 队列的唯一途径。仅处理本会话的帧。
+               ((equal type "session/queue")
+                (when (equal session-id
+                             (buffer-local-value
+                              'dsh-emacs--buffer-session chat))
+                  (dsh-emacs-queue-apply chat process payload)))
                ((equal type "session/projection")
                 (when (equal (dsh-emacs-render--aget "key" payload)
                              "contextPressure")

--- a/dsh-emacs-faces.el
+++ b/dsh-emacs-faces.el
@@ -487,6 +487,13 @@ Bold, no italic — matching dsh web's thinkingToggle style."
 	"Context usage > 80%."
 	:group 'dsh-emacs-faces)
 
+(defface dsh-emacs-modeline-queue-face
+	`((((background light)) :foreground "#b45f06")
+		(((background dark))  :foreground "#f0a63c")
+		(t :inherit warning))
+	"Pending-input queue indicator (`[Q2 S1]') in the mode line."
+	:group 'dsh-emacs-faces)
+
 ;;; ---------------------------------------------------------------------------
 ;;;  兼容 face 别名（0.1.0 时代叫 footer）
 ;;; ---------------------------------------------------------------------------

--- a/dsh-emacs-modeline.el
+++ b/dsh-emacs-modeline.el
@@ -42,6 +42,10 @@
 (declare-function doom-modeline-add-segment "doom-modeline-core" (segment anchor &optional position modeline))
 (declare-function doom-modeline-remove-segment "doom-modeline-core" (segment &optional modeline))
 
+;; 队列指示器（dsh-emacs 装配 dsh-emacs-queue，运行时反向读取）。
+(declare-function dsh-emacs-queue-counts "dsh-emacs-queue" ())
+(declare-function dsh-emacs-list-queue "dsh-emacs-queue" ())
+
 ;;; ---------------------------------------------------------------------------
 ;;; 定制
 ;;; ---------------------------------------------------------------------------
@@ -611,6 +615,30 @@ running (space on both sides, ready to sit right after the DSH mode name)."
                   'help-echo "dsh is running a request…"
                   'mouse-face 'mode-line-highlight))))
 
+(defun dsh-emacs-modeline--queue-indicator ()
+  "Return the pending-input queue indicator, e.g. \" [Q2 S1]\".
+Empty while nothing is pending, so the mode line is untouched; zero-count
+placements are omitted (\"[Q2]\", \"[S1]\").  Mouse-1 opens the queue
+manager.  `context' placement items (host-injected next-step content)
+are not counted, matching dsh web's QueueDock."
+  (if (derived-mode-p 'dsh-emacs-mode)
+      (let* ((counts (dsh-emacs-queue-counts))
+             (q (car counts))
+             (s (cdr counts))
+             (parts (append (unless (zerop q) (list (format "Q%d" q)))
+                            (unless (zerop s) (list (format "S%d" s))))))
+        (if parts
+            (propertize (format " [%s]" (string-join parts " "))
+                        'face 'dsh-emacs-modeline-queue-face
+                        'help-echo "Pending messages (queue/steer); mouse-1 to manage"
+                        'mouse-face 'mode-line-highlight
+                        'local-map (let ((map (make-sparse-keymap)))
+                                     (define-key map [mode-line mouse-1]
+                                                 #'dsh-emacs-list-queue)
+                                     map))
+          ""))
+    ""))
+
 (defun dsh-emacs-modeline--escape-percent (txt)
   "Escape `%' in TXT for mode-line display, keeping text properties.
 Mode-line strings undergo `%'-sequence expansion, so a literal `%' must be
@@ -658,8 +686,9 @@ visible at the left edge of the line instead of being clipped past the
 width-filling renderer.  BASE is the pre-existing mode-line-format list."
   (let* ((stats '(:eval (dsh-emacs-modeline--modeinline)))
          (anim '(:eval (dsh-emacs-modeline--ml-indicator)))
-         ;; 动画紧跟模式名（DSH 之后），统计段跟在动画后面。
-         (segments (list anim stats)))
+         (queue '(:eval (dsh-emacs-modeline--queue-indicator)))
+         ;; 动画与队列指示器紧跟模式名（DSH 之后），统计段跟在最后。
+         (segments (list anim queue stats)))
     (cond
      ((memq 'mode-line-modes base)
       ;; Insert directly after the mode names cluster.
@@ -682,6 +711,7 @@ outside a dsh-emacs buffer, so doom-modeline's layout stays untouched."
   (if (not (derived-mode-p 'dsh-emacs-mode))
       ""
     (concat (dsh-emacs-modeline--ml-indicator)
+            (dsh-emacs-modeline--queue-indicator)
             (dsh-emacs-modeline--modeinline))))
 
 (defun dsh-emacs-modeline--install-doom-segment ()

--- a/dsh-emacs-protocol.el
+++ b/dsh-emacs-protocol.el
@@ -38,6 +38,7 @@
 ;;                        └─ dsh-protocol-command-input (hint images)
 ;;   commands.execute → dsh-protocol-command-execution (command-id
 ;;                        result kind text)
+;;   session/queue    → dsh-protocol-queue-item (id placement text kind)
 ;;
 ;; 转换入口都接受 wire alist；注意 wire 中的数组（vector）在 struct 里
 ;; 一律归一为 list。业务代码写入缓存 struct 后，读取统一用 `dsh-protocol-*'
@@ -386,6 +387,54 @@ placeholder, IMAGES whether the command accepts inline images."
   result
   kind
   text)
+
+;; ---------------------------------------------------------------------------
+;; session/queue mux frame items
+;; ---------------------------------------------------------------------------
+
+;; The `session/queue' frame VALUE is `{items: [...]}' — one placement-tagged
+;; inbox entry per item.  Items map through
+;; `dsh-protocol-queue-item--from-alist' directly.
+
+(cl-defstruct (dsh-protocol-queue-item
+               (:constructor dsh-protocol-queue-item--from-alist
+                             (alist
+                              &aux
+                              (id (or (cdr (assq 'id alist))
+                                      (let ((m (cdr (assq 'message alist))))
+                                        (and m (cdr (assq 'id m))))))
+                              (placement
+                               (let ((p (cdr (assq 'placement alist))))
+                                 (and (stringp p) (intern p))))
+                              (text
+                               (let ((m (cdr (assq 'message alist))))
+                                 (mapconcat
+                                  (lambda (block)
+                                    (or (and (equal (cdr (assq 'type block))
+                                                    "text")
+                                             (cdr (assq 'text block)))
+                                        ""))
+                                  (dsh-protocol--list
+                                   (and m (cdr (assq 'content m))))
+                                  "")))
+                              (kind
+                               (let* ((m (cdr (assq 'message alist)))
+                                      (s (and m (cdr (assq 'source m)))))
+                                 (and s (cdr (assq 'kind s))))))))
+  "One `session/queue' frame item: PLACEMENT is `queued' (next turn),
+`steering' (next step) or `context' (host-injected next-step content);
+TEXT the message's text blocks concatenated, KIND the message's source
+kind (`user' for real user input)."
+  id
+  placement
+  text
+  kind)
+
+(defun dsh-protocol-queue-items-from-alist (value)
+  "Normalize a `session/queue' frame VALUE's items into structs."
+  (mapcar #'dsh-protocol-queue-item--from-alist
+          (dsh-protocol--list (and (listp value)
+                                   (cdr (assq 'items value))))))
 
 (defun dsh-protocol--struct (struct-alist-pred constructor value)
   "Return VALUE as a struct via CONSTRUCTOR if needed.

--- a/dsh-emacs-queue.el
+++ b/dsh-emacs-queue.el
@@ -1,0 +1,675 @@
+;;; dsh-emacs-queue.el --- Pending-input queue (queue/steer) for dsh-emacs -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 vritser
+
+;; Author: vritser
+;; Version: 0.1.0
+;; License: GPL-3.0-or-later
+;; Package-Requires: ((emacs "27.1"))
+
+;;; Commentary:
+
+;; Client-side mirror of the dsh agent inbox: input sent while a turn is
+;; running either queues as the next turn (`session.prompt' mode "queue")
+;; or steers the running agent before its next step (mode "steer").  The
+;; host publishes the authoritative snapshot as `session/queue' mux frames
+;; (on every inbox splice, plus once per connection for sessions with
+;; pending items), so this module only mirrors frames — there is no fetch
+;; RPC and no local bookkeeping that could drift.
+
+;; Emacs-native interaction (no panels, no overlays):
+;;   - mode line shows `[Q2 S1]' while items are pending (`context'
+;;     placement items — host-injected next-step content — are not counted,
+;;     matching dsh web's QueueDock);
+;;   - the echo area flashes transient feedback on enqueue / steer /
+;;     consumption, derived from the frame diff;
+;;   - `dsh-emacs-list-queue' (C-c C-q) opens the queue as a minibuffer
+;;     candidate list and applies single keys to the CURRENTLY highlighted
+;;     entry (vertico up/down picks the item — no numbering): e = edit,
+;;     s = steer, d = delete, RET = send now, x = delete the whole queue;
+;;   - while the queue is non-empty the input prompt carries a
+;;     clock-icon + text prefix preview (the `[next: …] ' brackets
+;;     appear only when Emacs lacks SVG image support).
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'dsh-emacs-protocol)
+(require 'dsh-emacs-faces)
+
+;; 同包模块的惰性边界（见 AGENTS.md）：dsh-emacs.el 装配本模块，运行时
+;; 反向调用其符号走 declare-function，避免顶层 require 环。
+(declare-function dsh-emacs--active-session-id "dsh-emacs" ())
+(declare-function dsh-emacs--busy-p "dsh-emacs" ())
+(declare-function dsh-emacs--replace-input "dsh-emacs" (text))
+(declare-function dsh-emacs--rpc-async "dsh-emacs" (method params callback))
+(declare-function dsh-emacs--submit-prompt "dsh-emacs" (message &optional images mode))
+(declare-function dsh-emacs-render--input-anchor-pos "dsh-emacs-render" ())
+
+(defvar dsh-emacs--input-marker)
+(defvar dsh-emacs--buffer-session)
+
+;;; ---------------------------------------------------------------------------
+;;; 状态镜像（buffer-local，随 mux 帧全量更新）
+;;; ---------------------------------------------------------------------------
+
+(defvar-local dsh-emacs--queue-items nil
+  "Pending inbox items of this chat's session, in delivery order.
+List of `dsh-protocol-queue-item'; replaced wholesale by every
+`session/queue' frame (the host snapshot is authoritative).")
+
+(defvar-local dsh-emacs--queue-process nil
+  "The mux process the current mirror was seeded from.
+A frame from a different process means a fresh connection whose first
+`session/queue' frame is the connect-time snapshot: apply it silently,
+without enqueue/steer/consumption echoes.")
+
+(defvar-local dsh-emacs--queue-deleted nil
+  "Item ids this client deleted via `session.updateQueue'.
+Their disappearance from the next frame is the delete being confirmed,
+not a consumption, so the `running' feedback is suppressed.  Ids are
+pruned once the confirming frame arrives.")
+
+(defvar-local dsh-emacs--queue-prefix nil
+  "The input-prompt prefix string currently shown before `❯ ', or nil.
+Compared byte-wise before removal, so a stale prefix after an input-area
+rebuild can never delete the wrong region.")
+
+(defvar-local dsh-emacs-queue--prefix-timer nil
+  "Pending zero-delay timer that repaints the prefix / mode-line.
+Queue frames arrive in bursts — the host often splices an item in and
+claims it again within milliseconds, and painting each frame would
+flash the `[next: …] ' prefix.  One repaint per burst, from the settled
+mirror, keeps such transient states invisible.")
+
+(defun dsh-emacs-queue-items ()
+  "Return this session's pending items (raw mirror, may be nil)."
+  dsh-emacs--queue-items)
+
+(defun dsh-emacs-queue--counts-of (items)
+  "Return (QUEUED . STEERING) counts of ITEMS, ignoring `context' entries."
+  (let ((q 0) (s 0))
+    (dolist (item items)
+      (pcase (dsh-protocol-queue-item-placement item)
+        ('queued (setq q (1+ q)))
+        ('steering (setq s (1+ s)))))
+    (cons q s)))
+
+(defun dsh-emacs-queue-counts ()
+  "Return (QUEUED . STEERING) pending counts for the current buffer."
+  (dsh-emacs-queue--counts-of dsh-emacs--queue-items))
+
+(defun dsh-emacs-queue-preview (text)
+  "Return TEXT as a one-line preview (first line, at most 40 chars)."
+  (let ((line (car (split-string (or text "") "\n"))))
+    (if (> (length line) 40)
+        (concat (substring line 0 37) "...")
+      line)))
+
+;;; ---------------------------------------------------------------------------
+;;; 帧应用 + 反馈（echo area）
+;;; ---------------------------------------------------------------------------
+
+(defun dsh-emacs-queue--find-id (items id)
+  "Return the item of ITEMS whose id is ID, or nil."
+  (cl-find id items :test #'string= :key #'dsh-protocol-queue-item-id))
+
+(defun dsh-emacs-queue--diff-events (old new deleted)
+  "Return the feedback implied by mirror transition OLD → NEW.
+DELETED lists locally-deleted ids whose disappearance is a confirmed
+delete, not a consumption.  Each event is (KIND . TEXT) with KIND one
+of `running', `steering' or `queued'; TEXT is a display preview."
+  (let ((events '()))
+    ;; 消费：id 从镜像中消失且不是本端删除（下一轮/下一步领取）。
+    (dolist (item old)
+      (let ((id (dsh-protocol-queue-item-id item)))
+        (when (and id
+                   (not (member id deleted))
+                   (null (dsh-emacs-queue--find-id new id)))
+          (push (cons 'running
+                      (dsh-emacs-queue-preview
+                       (dsh-protocol-queue-item-text item)))
+                events))))
+    ;; steering：新出现的 next-step 项，或从 queued 提升的项（本端或
+    ;; dsh web 另一端发起的 插队 都由此反馈）。
+    (dolist (item new)
+      (let* ((id (dsh-protocol-queue-item-id item))
+             (prev (and id (dsh-emacs-queue--find-id old id))))
+        (when (and (eq (dsh-protocol-queue-item-placement item) 'steering)
+                   (or (null prev)
+                       (not (eq (dsh-protocol-queue-item-placement prev)
+                                'steering))))
+          (push (cons 'steering
+                      (dsh-emacs-queue-preview
+                       (dsh-protocol-queue-item-text item)))
+                events))))
+    ;; queued：新出现的 next-turn 项（本端或另一端排队）。
+    (dolist (item new)
+      (let ((id (dsh-protocol-queue-item-id item)))
+        (when (and (eq (dsh-protocol-queue-item-placement item) 'queued)
+                   id
+                   (null (dsh-emacs-queue--find-id old id)))
+          (push (cons 'queued
+                      (dsh-emacs-queue-preview
+                       (dsh-protocol-queue-item-text item)))
+                events))))
+    (nreverse events)))
+
+(defun dsh-emacs-queue--flash (format &rest args)
+  "Show FORMAT/ARGS in the echo area and auto-dismiss it after ~2s.
+The clear is guarded: a message is only withdrawn while it is still the
+current one and no minibuffer session is active."
+  (let ((text (apply #'format format args)))
+    (message "%s" text)
+    (run-with-timer 2 nil
+                    (lambda ()
+                      (unless (active-minibuffer-window)
+                        (when (equal (current-message) text)
+                          (message nil)))))))
+
+(defun dsh-emacs-queue--announce (events)
+  "Flash the echo-area feedback for EVENTS."
+  (dolist (event events)
+    (pcase (car event)
+      ('running (dsh-emacs-queue--flash "running: %s" (cdr event)))
+      ('steering (dsh-emacs-queue--flash "steering: %s" (cdr event)))
+      ('queued (dsh-emacs-queue--flash "queued: %s" (cdr event))))))
+
+(defun dsh-emacs-queue-apply (chat process payload)
+  "Apply a `session/queue' frame PAYLOAD for CHAT arriving on PROCESS.
+The first frame of a connection is the connect-time snapshot and seeds
+the mirror silently; later frames diff against the mirror to emit the
+enqueue / steer / consumption feedback.  Payloads for other sessions
+are filtered out by the events dispatcher."
+  (when (buffer-live-p chat)
+    (with-current-buffer chat
+      (let* ((items (dsh-protocol-queue-items-from-alist payload))
+             (seed (not (eq process dsh-emacs--queue-process))))
+        (setq dsh-emacs--queue-process process)
+        (unless seed
+          (dsh-emacs-queue--announce
+           (dsh-emacs-queue--diff-events dsh-emacs--queue-items
+                                         items
+                                         dsh-emacs--queue-deleted)))
+        (setq dsh-emacs--queue-items items)
+        ;; 删除已被服务器确认（项已消失）：清掉抑制标记，避免吞掉后续
+        ;; 真实消费的反馈。
+        (setq dsh-emacs--queue-deleted
+              (cl-remove-if-not
+               (lambda (id)
+                 (dsh-emacs-queue--find-id items id))
+               dsh-emacs--queue-deleted))
+        (dsh-emacs-queue--schedule-paint)))))
+
+;;; ---------------------------------------------------------------------------
+;;; 输入行前缀预览：SVG 时钟图标 + 下一条提示 ❯
+;;; ---------------------------------------------------------------------------
+
+(defun dsh-emacs-queue--next-item ()
+  "Return the next message the host will send, or nil.
+The host delivers in-flight `steering' (next-step) items at the running
+agent's next step, before any `queued' (next-turn) item of the next
+turn, so the preview prefers the first steering item and falls back to
+the first queued one.  `context' items are host-injected content, not
+pending user messages — never previewed."
+  (or (cl-find-if (lambda (item)
+                    (eq (dsh-protocol-queue-item-placement item) 'steering))
+                  dsh-emacs--queue-items)
+      (cl-find-if (lambda (item)
+                    (eq (dsh-protocol-queue-item-placement item) 'queued))
+                  dsh-emacs--queue-items)))
+
+(defconst dsh-emacs-queue--next-icon-svg
+  "<svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M7.00049 0.199829C3.24488 0.199829 0.199952 3.24408 0.199707 6.99963C0.199707 8.0414 0.434087 9.03061 0.854004 9.91467L1.11279 10.4576L2.19775 9.94202L1.94092 9.39905L1.81787 9.12268C1.5498 8.46885 1.40186 7.75171 1.40186 6.99963C1.4021 3.90808 3.90888 1.40198 7.00049 1.40198C10.0919 1.40219 12.5979 3.90821 12.5981 6.99963C12.5981 10.0913 10.0921 12.5983 7.00049 12.5983C6.36734 12.5983 5.90348 12.5535 5.49268 12.4401C5.08803 12.3283 4.7041 12.1414 4.24463 11.8209C3.57111 11.3511 2.60588 11.1855 1.81006 11.6881L1.79736 11.6959L1.78467 11.7047L1.25537 12.0778L1.65381 13.2672L2.46045 12.6989C2.75029 12.5214 3.18004 12.5442 3.55615 12.8063C4.10063 13.1861 4.60863 13.4423 5.17334 13.5983C5.73194 13.7525 6.31665 13.8004 7.00049 13.8004C10.7561 13.8002 13.8003 10.7553 13.8003 6.99963C13.8 3.24421 10.7559 0.200041 7.00049 0.199829ZM3.81201 7.47327V8.67542H7.11572V7.47327H3.81201ZM3.81201 6.34924H10.2173V5.14709H3.81201V6.34924Z\" fill=\"currentColor\"></path></svg>"
+  "SVG data of the next-preview clock icon (14x14, filled via `currentColor').
+
+The `currentColor' value is mapped to the `:foreground' image property
+by `dsh-emacs-queue--next-icon', so the icon picks up the prompt face's
+color instead of a hard-coded one.")
+
+(defun dsh-emacs-queue--next-icon ()
+  "Return the clock-icon image string for the next-preview prefix, or nil.
+The result is a single space carrying the image `display' property plus
+the prompt face on its character, so the welcome prompt run stays
+contiguous.  nil when SVG images are unavailable (Emacs built without
+librsvg) — callers then fall back to the `[next: …] ' brackets."
+  (when (image-type-available-p 'svg)
+    (let ((fg (face-foreground 'dsh-emacs-input-prompt-face nil t)))
+      (propertize
+       " "
+       'face 'dsh-emacs-input-prompt-face
+       'display
+       (create-image dsh-emacs-queue--next-icon-svg
+                     'svg t
+                     :ascent 'center
+                     :scale 1.0
+                     :foreground (or fg "gray50"))))))
+
+(defun dsh-emacs-queue--prefix (preview)
+  "Build the input-prompt prefix showing PREVIEW.
+With SVG support the prefix is a clock icon followed by the preview
+text; otherwise the historical `[next: …] ' brackets are kept.  The
+whole string carries `dsh-emacs-input-prompt-face' (the icon keeps its
+`display' property), so prefix and `❯ ' merge into one prompt run and
+the anchor scan / byte-wise removal logic stays intact."
+  (let ((icon (dsh-emacs-queue--next-icon)))
+    (if icon
+        (propertize (concat icon " " preview " ")
+                    'face 'dsh-emacs-input-prompt-face)
+      (propertize (format "[next: %s] " preview)
+                  'face 'dsh-emacs-input-prompt-face))))
+
+(defun dsh-emacs-queue--paint-after-burst ()
+  "Repaint the next-preview prefix and mode-line from the CURRENT mirror.
+Runs once per frame burst (zero-delay timer); the mirror already holds
+the settled state, so a transient item that was spliced and instantly
+claimed never surfaces in the prefix."
+  (setq dsh-emacs-queue--prefix-timer nil)
+  (when (and dsh-emacs--input-marker
+             (marker-buffer dsh-emacs--input-marker))
+    (dsh-emacs-queue--update-prefix)
+    (force-mode-line-update)))
+
+(defun dsh-emacs-queue--schedule-paint ()
+  "Schedule one prefix/mode-line repaint for the current frame burst.
+Further frames arriving before the timer fires (same burst) are folded
+into the same repaint — see `dsh-emacs-queue--prefix-timer'."
+  (unless dsh-emacs-queue--prefix-timer
+    (let ((buf (current-buffer)))
+      (setq dsh-emacs-queue--prefix-timer
+            (run-at-time
+             0 nil
+             (lambda ()
+               (when (buffer-live-p buf)
+                 (with-current-buffer buf
+                   (dsh-emacs-queue--paint-after-burst)))))))))
+
+(defun dsh-emacs-queue--update-prefix ()
+  "Sync the next-preview prompt prefix (clock icon + text) with the mirror.
+The prefix sits in the read-only welcome region (prompt face run, so
+the input anchor keeps pointing at the run start); edits go through
+`inhibit-read-only' and the previous prefix is removed only when it is
+still exactly what this module inserted."
+  (when (and dsh-emacs--input-marker
+             (marker-buffer dsh-emacs--input-marker))
+    (let* ((anchor (dsh-emacs-render--input-anchor-pos))
+           (next (dsh-emacs-queue--next-item))
+           (wanted (and anchor next
+                        (dsh-emacs-queue--prefix
+                         (dsh-emacs-queue-preview
+                          (dsh-protocol-queue-item-text next))))))
+      (when anchor
+        (let ((inhibit-read-only t)
+              (old (and dsh-emacs--queue-prefix
+                        (length dsh-emacs--queue-prefix))))
+          (when (and old
+                     (> old 0)
+                     (<= (+ anchor old) (point-max))
+                     (string= (buffer-substring-no-properties
+                               anchor (+ anchor old))
+                              dsh-emacs--queue-prefix))
+            (delete-region anchor (+ anchor old)))
+          (setq dsh-emacs--queue-prefix nil)
+          (when wanted
+            (goto-char anchor)
+            (insert wanted)
+            (setq dsh-emacs--queue-prefix wanted)))))))
+
+(defun dsh-emacs-queue--refresh-ui ()
+  "Recompute the input-prompt next preview and the mode-line counts.
+Optimistic path (steer/delete/edit RPC success): paint right away and
+drop any pending burst repaint, so our own actions stay instantaneous."
+  (when (timerp dsh-emacs-queue--prefix-timer)
+    (cancel-timer dsh-emacs-queue--prefix-timer))
+  (setq dsh-emacs-queue--prefix-timer nil)
+  (dsh-emacs-queue--paint-after-burst))
+
+;;; ---------------------------------------------------------------------------
+;;; RPC：session.updateQueue（edit / remove / steer）
+;;; ---------------------------------------------------------------------------
+
+(defun dsh-emacs-queue--session-id ()
+  "Return the session id this queue manages, or error when none is open."
+  (or (dsh-emacs--active-session-id)
+      (user-error "No session is open")))
+
+(defun dsh-emacs-queue--update (item-id action &optional on-error on-success)
+  "Send one `session.updateQueue' call for ITEM-ID with ACTION.
+ACTION is the wire action alist (e.g. ((kind . \"remove\"))).  ON-ERROR
+runs in the chat buffer when the call fails; ON-SUCCESS when it
+succeeds — both with the chat buffer current.  The mirror is normally
+confirmed by the following `session/queue' frame; ON-SUCCESS is where
+this client applies our own actions OPTIMISTICALLY, so steer / delete /
+edit update the next-preview hint and the mode-line the instant the
+RPC succeeds, without waiting for the frame round-trip."
+  (let ((session-id (dsh-emacs-queue--session-id))
+        (buf (current-buffer)))
+    (dsh-emacs--rpc-async
+     "session.updateQueue"
+     `((sessionId . ,session-id)
+       (itemId . ,item-id)
+       (action . ,action))
+     (lambda (ok value)
+       (when (buffer-live-p buf)
+         (with-current-buffer buf
+           (if ok
+               (when on-success (funcall on-success value))
+             (when on-error (funcall on-error value))
+             (message "Queue update failed: %S" value))))))))
+
+(defun dsh-emacs-queue--delete (item)
+  "Delete ITEM via `session.updateQueue' (kind remove)."
+  (let ((id (dsh-protocol-queue-item-id item)))
+    (push id dsh-emacs--queue-deleted)
+    (dsh-emacs-queue--update
+     id '((kind . "remove"))
+     (lambda (_value)
+       ;; 删除失败：项仍在队列里，恢复消费反馈的口径。
+       (setq dsh-emacs--queue-deleted
+             (delete id dsh-emacs--queue-deleted)))
+     (lambda (_value)
+       ;; 删除成功：乐观移除（确认帧随后全量覆盖镜像）+ 输入行闪现。
+       (setq dsh-emacs--queue-items
+             (cl-remove-if (lambda (it)
+                             (equal id (dsh-protocol-queue-item-id it)))
+                           dsh-emacs--queue-items))
+       (dsh-emacs-queue--refresh-ui)))))
+
+(defun dsh-emacs-queue--steer (item)
+  "Promote queued ITEM into the running turn (kind steer).
+On success the mirror is updated optimistically (placement → steering)
+and the hint recomputed, so the promotion is visible before the
+confirming `session/queue' frames arrive.  The id joins the
+deleted-suppression list so the transient removal frame is never
+announced as a consumption (`running'); the `steering' feedback still
+rides the re-insertion frame's diff (the mirror is cleared in between)."
+  (let ((id (dsh-protocol-queue-item-id item)))
+    (dsh-emacs-queue--update
+     id '((kind . "steer"))
+     nil
+     (lambda (_value)
+       (push id dsh-emacs--queue-deleted)
+       (setq dsh-emacs--queue-items
+             (mapcar (lambda (it)
+                       (if (equal id (dsh-protocol-queue-item-id it))
+                           (progn
+                             (setf (dsh-protocol-queue-item-placement it)
+                                   'steering)
+                             it)
+                         it))
+                     dsh-emacs--queue-items))
+       (dsh-emacs-queue--refresh-ui)))))
+
+(defun dsh-emacs-queue--edit (item new-text)
+  "Replace ITEM's text with NEW-TEXT (kind edit, text blocks only).
+On success the mirror is updated optimistically so the hint shows the
+edited preview at once; the confirming frame overwrites the mirror."
+  (let ((id (dsh-protocol-queue-item-id item)))
+    (dsh-emacs-queue--update
+     id
+     `((kind . "edit")
+       (content . ,(vector (list (cons 'type "text")
+                                 (cons 'text new-text)))))
+     nil
+     (lambda (_value)
+       (dolist (it dsh-emacs--queue-items)
+         (when (equal id (dsh-protocol-queue-item-id it))
+           (setf (dsh-protocol-queue-item-text it) new-text)))
+       (dsh-emacs-queue--refresh-ui)))))
+
+;;; ---------------------------------------------------------------------------
+;;; 管理界面：C-c C-q（completing-read，Vertico/Ivy/Helm 兼容）
+;;; ---------------------------------------------------------------------------
+
+(defun dsh-emacs-queue--send-now (item)
+  "Send ITEM right away.
+While a turn is running this steers it into the running turn (jump the
+queue).  While idle there is no wake-only RPC: the item is deleted and
+re-submitted as an ordinary prompt, which wakes the driver — the parked
+queue drains in order and the re-submitted copy re-joins at the tail
+with its text preserved."
+  (if (eq (dsh-protocol-queue-item-placement item) 'steering)
+      (message "Already steering")
+    (if (dsh-emacs--busy-p)
+        (dsh-emacs-queue--steer item)
+      (let* ((text (dsh-protocol-queue-item-text item))
+             (id (dsh-protocol-queue-item-id item))
+             (session-id (dsh-emacs-queue--session-id))
+             (buf (current-buffer)))
+        (push id dsh-emacs--queue-deleted) ; 发送即删除：确认帧不当作消费
+        (dsh-emacs--rpc-async
+         "session.updateQueue"
+         `((sessionId . ,session-id)
+           (itemId . ,id)
+           (action . ((kind . "remove"))))
+         (lambda (ok value)
+           (when (buffer-live-p buf)
+             (with-current-buffer buf
+               (if ok
+                   (progn
+                     ;; 乐观移除 + 输入行闪现，再重提交（失败绝不重发）。
+                     (setq dsh-emacs--queue-items
+                           (cl-remove-if
+                            (lambda (it)
+                              (equal id (dsh-protocol-queue-item-id it)))
+                            dsh-emacs--queue-items))
+                     (dsh-emacs-queue--refresh-ui)
+                     (dsh-emacs--submit-prompt text))
+                 (progn
+                   (setq dsh-emacs--queue-deleted
+                         (delete id dsh-emacs--queue-deleted))
+                   (message "Queue update failed: %S" value)))))))))))
+
+(defun dsh-emacs-queue--label (item)
+  "Return the queue-menu label for ITEM, e.g. \"[Q] fix the bug\"."
+  (format "[%c] %s"
+          (if (eq (dsh-protocol-queue-item-placement item) 'steering)
+              ?S ?Q)
+          (dsh-emacs-queue-preview (dsh-protocol-queue-item-text item))))
+
+(defun dsh-emacs-queue--table (items)
+  "Return ((LABEL . ITEM) ...) for ITEMS with unique LABELs:
+items whose preview text collides get a \"[N]\" suffix, so each label
+maps back to exactly one item however the minibuffer picked it."
+  (let ((seen (make-hash-table :test 'equal)))
+    (mapcar (lambda (item)
+              (let* ((base (dsh-emacs-queue--label item))
+                     (n (1+ (gethash base seen 0))))
+                (puthash base n seen)
+                (cons (if (= n 1) base
+                        (format "%s [%d]" base n))
+                      item)))
+            items)))
+
+(defvar dsh-emacs--queue-pick-table nil
+  "((LABEL . ITEM) ...): the queue entries of the open queue menu.
+A DYNAMIC binding set by `dsh-emacs-list-queue' around the
+`completing-read'; the single-key menu commands resolve the entry they
+act on through this table — the same pattern as
+`dsh-emacs--question-pick-labels'.")
+
+(defun dsh-emacs-queue--menu-item ()
+  "The ITEM the next menu key acts on: the vertico-highlighted
+candidate when vertico renders the list; else the minibuffer's typed
+input as an exact/prefix match on the labels; else the first entry
+(the next to run).
+The highlighted candidate is read straight off `vertico--index' /
+`vertico--candidates' rather than through an accessor like
+`vertico--current', which no longer exists in current vertico
+(renamed to `vertico--candidate', whose return additionally prepends
+`vertico--base' after the user typed input).  `equal' ignores text
+properties, so the face vertico puts on the candidate does not break
+the table lookup."
+  (let* ((vertico-active (and (bound-and-true-p vertico-mode)
+                              (boundp 'vertico--candidates)
+                              (boundp 'vertico--index)
+                              (>= vertico--index 0)))
+         (hl (and vertico-active
+                  (ignore-errors
+                    (nth vertico--index vertico--candidates))))
+         (typed (condition-case nil (minibuffer-contents) (error nil)))
+         (entry (or (and hl
+                         (assoc hl dsh-emacs--queue-pick-table))
+                    (and typed
+                         (assoc typed dsh-emacs--queue-pick-table))
+                    (and typed
+                         (let ((hit (car (all-completions
+                                          typed
+                                          (mapcar #'car
+                                                  dsh-emacs--queue-pick-table)))))
+                           (and hit
+                                (assoc hit dsh-emacs--queue-pick-table))))
+                    (car dsh-emacs--queue-pick-table))))
+    (cdr entry)))
+
+(defun dsh-emacs-queue--menu-chat ()
+  "The chat buffer the queue menu was opened from."
+  (window-buffer (minibuffer-selected-window)))
+
+(defun dsh-emacs-queue--menu-run (fn)
+  "Close the queue minibuffer and run FN on the picked item, in the
+chat buffer the menu was opened from (RPC/input state stay the
+session's own).  FN is deferred through `run-at-time 0': inside a
+minibuffer command, nothing after `exit-minibuffer' is ever executed
+— the exit THROWS out of the recursive minibuffer edit, abandoning
+the rest of the command — so the action must be scheduled BEFORE the
+exit and fired once the minibuffer is gone (same pattern as the `e'
+and `x' keys)."
+  (let* ((chat (dsh-emacs-queue--menu-chat))
+         (item (dsh-emacs-queue--menu-item)))
+    ;; 定时器必须排在 exit 之前：`exit-minibuffer' 会 throw 离开
+    ;; 命令，之后的代码永不执行。
+    (run-at-time 0 nil
+                 (lambda ()
+                   (when (and (buffer-live-p chat) item)
+                     (with-current-buffer chat
+                       (funcall fn item)))))
+    (exit-minibuffer)))
+
+(defun dsh-emacs-queue--menu-edit ()
+  "Edit the picked entry's text (`e')."
+  (interactive)
+  (let* ((chat (dsh-emacs-queue--menu-chat))
+         (item (dsh-emacs-queue--menu-item)))
+    ;; 定时器先于 exit 注册，exit 后 minibuffer 已关，read-string
+    ;; 不再嵌套在 recursive minibuffer 里（提示不会被吞）。
+    (run-at-time 0 nil
+                 (lambda ()
+                   (when (and (buffer-live-p chat) item)
+                     (with-current-buffer chat
+                       (let ((text (read-string
+                                    "Edit queued message: "
+                                    (dsh-protocol-queue-item-text item))))
+                         (unless (string-empty-p (string-trim text))
+                           (dsh-emacs-queue--edit item text)))))))
+    (exit-minibuffer)))
+
+(defun dsh-emacs-queue--menu-steer ()
+  "Steer the picked entry into the running turn (`s')."
+  (interactive)
+  (dsh-emacs-queue--menu-run
+   (lambda (item)
+     (cond
+      ((eq (dsh-protocol-queue-item-placement item) 'steering)
+       (message "Already steering"))
+      ((not (dsh-emacs--busy-p))
+       (message "No turn is running — RET sends it now"))
+      (t (dsh-emacs-queue--steer item))))))
+
+(defun dsh-emacs-queue--menu-delete ()
+  "Delete the picked entry (`d')."
+  (interactive)
+  (dsh-emacs-queue--menu-run #'dsh-emacs-queue--delete))
+
+(defun dsh-emacs-queue--menu-send ()
+  "Send the picked entry now (`RET')."
+  (interactive)
+  (dsh-emacs-queue--menu-run #'dsh-emacs-queue--send-now))
+
+(defun dsh-emacs-queue--menu-delete-all ()
+  "Delete the whole queue after confirmation (`x')."
+  (interactive)
+  (let* ((chat (dsh-emacs-queue--menu-chat))
+         (items (delq nil (mapcar #'cdr dsh-emacs--queue-pick-table))))
+    ;; 定时器先于 exit 注册（exit 的 throw 会丢弃命令剩余代码）。
+    (run-at-time 0 nil
+                 (lambda ()
+                   (when (buffer-live-p chat)
+                     (with-current-buffer chat
+                       (when (y-or-n-p
+                              (format "Delete all %d queued item%s? "
+                                      (length items)
+                                      (if (= (length items) 1) "" "s")))
+                         (dolist (it items)
+                           (dsh-emacs-queue--delete it)))))))
+    (exit-minibuffer)))
+
+(defun dsh-emacs-queue--chooser-keymap ()
+  "Minibuffer keymap for the queue menu: `e'/`s'/`d'/`RET' act on the
+picked entry, `x' deletes the whole queue.  Built exactly like the
+question chooser's (`dsh-emacs--question-chooser-keymap'): a copy of
+the minibuffer's current local map (vertico's when active, so its
+navigation keys survive) plus our single keys.  Mounted last in the
+minibuffer-setup-hook chain (`minibuffer-with-setup-hook' prepends its
+hook, so vertico's `use-local-map vertico-map' has already run), which
+is what makes the keys win."
+  (let ((map (copy-keymap (or (current-local-map)
+                              (make-sparse-keymap)))))
+    (define-key map (kbd "e") #'dsh-emacs-queue--menu-edit)
+    (define-key map (kbd "s") #'dsh-emacs-queue--menu-steer)
+    (define-key map (kbd "d") #'dsh-emacs-queue--menu-delete)
+    (define-key map (kbd "x") #'dsh-emacs-queue--menu-delete-all)
+    (define-key map (kbd "RET") #'dsh-emacs-queue--menu-send)
+    map))
+
+(defun dsh-emacs-queue--chooser-setup-hook ()
+  "Queue-menu minibuffer setup: stable candidate order (no completion
+re-sort), first entry preselected, single-key map mounted.  Same as the
+question chooser's setup — because `minibuffer-with-setup-hook'
+prepends, this hook runs AFTER vertico's and its `use-local-map' wins.
+Returns nil explicitly — `minibuffer-with-setup-hook' funcalls the
+setup value."
+  (when (boundp 'vertico-sort-function)
+    (setq-local vertico-sort-function nil))
+  (when (boundp 'vertico-sort-override-function)
+    (setq-local vertico-sort-override-function nil))
+  (when (boundp 'vertico-preselect)
+    (setq-local vertico-preselect 'first))
+  (use-local-map (dsh-emacs-queue--chooser-keymap))
+  nil)
+
+(defun dsh-emacs-list-queue ()
+  "Manage this session's pending queue (minibuffer menu).
+Opens the queue as a candidate list (`[Q]' queued, `[S]' steering;
+vertico/icomplete up/down moves) and acts on the picked entry with the
+SINGLE keys bound inside the minibuffer — no numbering, no separate
+selection step: `e' edit the current entry's text, `s' steer it into
+the running turn, `d' delete it, `x' delete the whole queue (after
+confirmation), `RET' send it now (steer while a turn runs; while idle
+it wakes the queue drain).  One `C-g' cancels.  Keys and RPCs run back
+in the chat buffer the menu was opened from.  Host-injected `context'
+items are never shown or acted on."
+  (interactive)
+  (dsh-emacs-queue--session-id)
+  ;; C-g 一次彻底退出（菜单、编辑、全删确认），不留半开 minibuffer。
+  (condition-case nil
+      (let* ((items (cl-remove-if
+                     (lambda (item)
+                       (eq (dsh-protocol-queue-item-placement item) 'context))
+                     dsh-emacs--queue-items)))
+        (when (null items)
+          (user-error "Queue is empty"))
+        (let* ((table (dsh-emacs-queue--table items))
+               (dsh-emacs--queue-pick-table table))
+          (minibuffer-with-setup-hook
+              (lambda () (dsh-emacs-queue--chooser-setup-hook))
+            (completing-read
+             (format "Queue Q%d S%d — e edit, s steer, d delete, x all, RET send: "
+                     (car (dsh-emacs-queue-counts))
+                     (cdr (dsh-emacs-queue-counts)))
+             (mapcar #'car table) nil nil nil nil nil))))
+    (quit (message "Queue manager cancelled"))))
+
+(provide 'dsh-emacs-queue)
+
+;;; dsh-emacs-queue.el ends here

--- a/dsh-emacs.el
+++ b/dsh-emacs.el
@@ -26,7 +26,10 @@
 ;;   M-x dsh-emacs-new-session        ; 新建会话
 ;;
 ;; 对话缓冲键位：
-;;   C-c C-c   发送/中断
+;;   C-c C-c   发送（运行中按 `dsh-emacs-busy-enter-behavior' 入队/引导，
+;;             空输入或 `C-u' 反转时为中断/引导）
+;;   C-c C-b   中断当前轮
+;;   C-c C-q   管理待发队列（编辑/引导/删除/立即发送）
 ;;   C-c C-r   刷新
 ;;   C-c C-l   打开会话列表
 ;;   C-c C-w   复制转录
@@ -58,6 +61,7 @@
 (require 'dsh-emacs-render)
 (require 'dsh-emacs-events)
 (require 'dsh-emacs-modeline)
+(require 'dsh-emacs-queue)
 (require 'dsh-emacs-server)
 (require 'dsh-emacs-command)
 (require 'dsh-emacs-session)
@@ -171,6 +175,19 @@ of its own), so only files resolving to one of these types are sent."
 (defcustom dsh-emacs-input-history-length 50
   "Maximum number of submitted prompts kept for `M-p' / `M-n' recall."
   :type 'integer
+  :group 'dsh-emacs)
+
+(defcustom dsh-emacs-busy-enter-behavior 'queue
+  "What `\\[dsh-emacs-send-or-stop]' does with input while a turn is running.
+Mirrors dsh web's `busyEnter' setting: `queue' lines the input up as the
+next turn (delivered automatically when the current one finishes),
+`steer' wakes the running agent and redirects its current work, and
+`stop' keeps the old behavior of interrupting the turn.  With `queue' or
+`steer', an empty input still interrupts, and `\\[universal-argument]
+\\[dsh-emacs-send-or-stop]' flips queue and steer for one send."
+  :type '(choice (const :tag "Queue as the next turn" queue)
+                 (const :tag "Steer the running turn" steer)
+                 (const :tag "Interrupt the turn" stop))
   :group 'dsh-emacs)
 
 (defcustom dsh-emacs-question-skip-key "s"
@@ -1653,6 +1670,8 @@ the session list regroups immediately (the host stream also repaints)."
 (defvar dsh-emacs-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") #'dsh-emacs-send-or-stop)
+    (define-key map (kbd "C-c C-b") #'dsh-emacs-interrupt-turn)
+    (define-key map (kbd "C-c C-q") #'dsh-emacs-list-queue)
     (define-key map (kbd "C-c C-r") #'dsh-emacs-refresh)
     (define-key map (kbd "C-c C-l") #'dsh-emacs-list-sessions-display)
     (define-key map (kbd "C-c C-s") #'dsh-emacs-switch-workspace-session)
@@ -1808,7 +1827,7 @@ All welcome text is marked read-only; only the region after ❯ is writable."
     (let ((welcome-start (point)))
       (insert (propertize "dsh  " 'face 'dsh-emacs-accent-face))
       (insert (propertize "DeepSeek Harness\n" 'face 'dsh-emacs-header-face))
-      (insert (propertize "C-c C-c send   ·   C-c C-r refresh   ·   C-c C-l session list\n\n"
+      (insert (propertize "C-c C-c send   ·   C-c C-q queue   ·   C-c C-r refresh   ·   C-c C-l session list\n\n"
                           'face 'dsh-emacs-hint-face))
       ;; 输入提示符
       (insert (propertize "❯ " 'face 'dsh-emacs-input-prompt-face))
@@ -1855,11 +1874,13 @@ editing inside an earlier one."
 Consults the same buffer-local flag that drives the mode-line spinner."
   (and (boundp 'dsh-emacs--ml-busy) dsh-emacs--ml-busy))
 
-(defun dsh-emacs--interrupt-turn ()
+(defun dsh-emacs-interrupt-turn ()
   "Interrupt the running turn via `session.cancel'.
 
 The server stops the agent mid-flight; the partial reply stays in the
-transcript and `turn/end' arrives normally, which clears the spinner."
+transcript and `turn/end' arrives normally, which clears the spinner.
+The pending-input queue is kept host-side: parked items stay parked
+until the next wake (see `dsh-emacs-list-queue')."
   (let ((session-id (dsh-emacs--active-session-id)))
     (when (null session-id)
       (user-error "No session is open"))
@@ -1876,16 +1897,31 @@ transcript and `turn/end' arrives normally, which clears the spinner."
                               (message "Failed to interrupt: %S" value))))))
 
 (defun dsh-emacs-send-or-stop ()
-  "Send the input as a message, or interrupt the running turn.
+  "Send the input as a message, or act on the running turn.
 
-While a turn is executing (the mode-line spinner is lit) another
-`C-c C-c' issues `session.cancel' instead of queueing a second message:
-the agent stops, the partial reply is kept in the transcript.  When idle,
-the text after the `❯ ' prompt is submitted."
+When idle, the text after the `❯ ' prompt is submitted.  While a turn is
+executing (the mode-line spinner is lit) the input is delivered per
+`dsh-emacs-busy-enter-behavior': `queue' lines it up as the next turn,
+`steer' wakes the running agent, `stop' issues `session.cancel' (the old
+interrupt behavior).  With `queue'/`steer' and an EMPTY input the turn is
+interrupted, so stopping stays one key away, and `C-u' flips queue and
+steer for one send.  Success feedback (queued / steering reports) arrives
+via the `session/queue' stream; `\\[dsh-emacs-interrupt-turn]'
+(`C-c C-b') interrupts regardless of the behavior."
   (interactive)
   (dsh-emacs-server-ensure)
   (if (dsh-emacs--busy-p)
-      (dsh-emacs--interrupt-turn)
+      (let ((behavior (if (and (consp current-prefix-arg)
+                               (not (eq dsh-emacs-busy-enter-behavior 'stop)))
+                          (if (eq dsh-emacs-busy-enter-behavior 'steer)
+                              'queue 'steer)
+                        dsh-emacs-busy-enter-behavior)))
+        (if (eq behavior 'stop)
+            (dsh-emacs-interrupt-turn)
+          (let ((input (dsh-emacs--get-input)))
+            (if (string-empty-p (string-trim input))
+                (dsh-emacs-interrupt-turn)
+              (dsh-emacs--submit-prompt input nil behavior)))))
     (let ((input (dsh-emacs--get-input)))
       (if (string-empty-p (string-trim input))
           (message "Please enter a message")
@@ -2009,8 +2045,17 @@ ambiguous and are not accepted by the dsh API."
       (when (> (length dsh-emacs--input-history) len)
         (setcdr (nthcdr (1- len) dsh-emacs--input-history) nil)))))
 
-(defun dsh-emacs--submit-prompt (message &optional images)
+(defun dsh-emacs--submit-prompt (message &optional images mode)
   "Submit MESSAGE to the current session.
+
+Non-nil MODE (\"queue\" or \"steer\") submits the message into a
+RUNNING turn's inbox instead of starting one — the deferred path of
+`dsh-emacs--submit-deferred', which neither renders a transcript card
+nor touches the spinner.  With MODE nil while the session is already
+busy (e.g. `C-c C-a' during a run), the configured
+`dsh-emacs-busy-enter-behavior' picks the mode; with `stop' the deferred
+path is never taken (`C-c C-c' interrupts then, attach-file keeps
+sending a plain queue-mode prompt as before).
 
 Slash-command lines (leading \"/name\") are routed to
 `commands.execute' instead of the model: the host admits only
@@ -2021,48 +2066,106 @@ given, is a list of wire-ready attachment alists
 \((mediaType . M) (data . B64) (name . N)); they are appended to the
 `content' array of `session.prompt' as `{type: \"image\"}' parts so
 the model sees them immediately."
-  (if (dsh-emacs-command-parse message)
-      (let ((session-id (dsh-emacs--active-session-id))
-            (input-buffer (current-buffer)))
-        ;; 提交即清空输入区、记入输入历史——不等 RPC 往返（网页同款手感）：
-        ;; 命令是否被 host 受理由 `commands.execute' 的响应决定，结果由
-        ;; command/run + command/done 会话事件渲染。
-        (dsh-emacs--push-input-history message)
-        (setq dsh-emacs--input-history-pos nil
-              dsh-emacs--input-history-pending nil)
-        (when (buffer-live-p input-buffer)
-          (with-current-buffer input-buffer
-            (dsh-emacs--clear-input)))
-        ;; 立即渲染命令行（乐观路径）——不等 RPC 往返。
-        (when (buffer-live-p input-buffer)
-          (with-current-buffer input-buffer
-            (dsh-emacs-render-command-optimistic message)))
-        (dsh-emacs-command-execute
-         session-id (string-trim message) images
-         (lambda (ok execution err)
-           ;; 回调可能运行在 process filter 里：吞掉 C-g 的 quit。
-           (condition-case nil
-               (cond
-                ((null ok)
-                 ;; 传输失败（HTTP/解析错误）：清除乐观行，恢复原文。
-                 (when (buffer-live-p input-buffer)
-                   (with-current-buffer input-buffer
-                     (dsh-emacs-render-command-cleanup-optimistic)
-                     (when (string-empty-p
-                            (or (dsh-emacs--get-input) ""))
-                       (dsh-emacs--replace-input message))))
-                 (message "Command failed to run: %S"
-                          (or err "transport error")))
-                ((null execution)
-                 ;; 未命中注册表 → 清除乐观行，按普通消息发送（浏览器同款语义）；
-                 ;; 历史已在提交时记录，不再重复记入。
-                 (when (buffer-live-p input-buffer)
-                   (with-current-buffer input-buffer
-                     (dsh-emacs-render-command-cleanup-optimistic)))
-                 (dsh-emacs--submit-plain message images t))
-                (t nil))       ; 受理：乐观行由 command/run 事件替换
-             (quit nil)))))
-    (dsh-emacs--submit-plain message images)))
+  (if (or mode
+          (and (dsh-emacs--busy-p)
+               (not (eq dsh-emacs-busy-enter-behavior 'stop))))
+      (dsh-emacs--submit-deferred message images mode)
+    (if (dsh-emacs-command-parse message)
+        (let ((session-id (dsh-emacs--active-session-id))
+              (input-buffer (current-buffer)))
+          ;; 提交即清空输入区、记入输入历史——不等 RPC 往返（网页同款手感）：
+          ;; 命令是否被 host 受理由 `commands.execute' 的响应决定，结果由
+          ;; command/run + command/done 会话事件渲染。
+          (dsh-emacs--push-input-history message)
+          (setq dsh-emacs--input-history-pos nil
+                dsh-emacs--input-history-pending nil)
+          (when (buffer-live-p input-buffer)
+            (with-current-buffer input-buffer
+              (dsh-emacs--clear-input)))
+          ;; 立即渲染命令行（乐观路径）——不等 RPC 往返。
+          (when (buffer-live-p input-buffer)
+            (with-current-buffer input-buffer
+              (dsh-emacs-render-command-optimistic message)))
+          (dsh-emacs-command-execute
+           session-id (string-trim message) images
+           (lambda (ok execution err)
+             ;; 回调可能运行在 process filter 里：吞掉 C-g 的 quit。
+             (condition-case nil
+                 (cond
+                  ((null ok)
+                   ;; 传输失败（HTTP/解析错误）：清除乐观行，恢复原文。
+                   (when (buffer-live-p input-buffer)
+                     (with-current-buffer input-buffer
+                       (dsh-emacs-render-command-cleanup-optimistic)
+                       (when (string-empty-p
+                              (or (dsh-emacs--get-input) ""))
+                         (dsh-emacs--replace-input message))))
+                   (message "Command failed to run: %S"
+                            (or err "transport error")))
+                  ((null execution)
+                   ;; 未命中注册表 → 清除乐观行，按普通消息发送（浏览器同款语义）；
+                   ;; 历史已在提交时记录，不再重复记入。
+                   (when (buffer-live-p input-buffer)
+                     (with-current-buffer input-buffer
+                       (dsh-emacs-render-command-cleanup-optimistic)))
+                   (dsh-emacs--submit-plain message images t))
+                  (t nil))       ; 受理：乐观行由 command/run 事件替换
+               (quit nil)))))
+      (dsh-emacs--submit-plain message images))))
+
+(defun dsh-emacs--submit-deferred (message images mode)
+  "Submit MESSAGE into the running turn's inbox as MODE.
+MODE is `queue' (line up as the next turn) or `steer' (wake the running
+agent before its next step); nil means resolve from
+`dsh-emacs-busy-enter-behavior'.  The wire call is `session.prompt' with
+the mode field.  Unlike `dsh-emacs--submit-plain' this renders NO
+optimistic transcript card and does not touch the spinner: the item is
+not part of the conversation until the host claims it (the durable
+`user/message' event renders then), and the queue/steer feedback rides
+the `session/queue' frame the host pushes on the splice.  IMAGES is the
+same wire-ready attachment list `dsh-emacs--submit-prompt' takes; the
+host admits images by the session's current model at claim time.  Slash
+lines are NOT routed to `commands.execute' here — busy input is queued
+as literal text, the same semantics as dsh web's busyEnter."
+  (let* ((mode (pcase mode
+                 ((or 'queue 'steer) (symbol-name mode))
+                 ('stop "queue")
+                 (_ (symbol-name dsh-emacs-busy-enter-behavior))))
+         (session-id (dsh-emacs--active-session-id))
+         (input-buffer (current-buffer))
+         (content (vconcat `(((type . "text") (text . ,message)))
+                           (mapcar (lambda (attachment)
+                                     (cons '(type . "image") attachment))
+                                   images)))
+         (payload `((sessionId . ,session-id)
+                    (mode . ,mode)
+                    (content . ,content)
+                    (clientTimeZone . ,(dsh-emacs--client-time-zone)))))
+    ;; Same web-style feel as the immediate path: the draft leaves the
+    ;; input area and lands in history right away, before the RPC settles.
+    (dsh-emacs--push-input-history message)
+    (setq dsh-emacs--input-history-pos nil
+          dsh-emacs--input-history-pending nil)
+    (when (buffer-live-p input-buffer)
+      (with-current-buffer input-buffer
+        (dsh-emacs--clear-input)))
+    (dsh-emacs--rpc-async "session.prompt" payload
+                          (lambda (ok value)
+                            (if ok
+                                ;; Enqueue/steer feedback arrives via the
+                                ;; `session/queue' frame diff — and the
+                                ;; transcript shows the message when the
+                                ;; host claims it (user/message).  Nothing
+                                ;; to render here.
+                                nil
+                              (message "Failed to submit: %S" value)
+                              ;; Nothing will consume the text, put it back
+                              ;; (same restore as the command path).
+                              (when (buffer-live-p input-buffer)
+                                (with-current-buffer input-buffer
+                                  (when (string-empty-p
+                                         (or (dsh-emacs--get-input) ""))
+                                    (dsh-emacs--replace-input message)))))))))
 
 (defun dsh-emacs--submit-plain (message &optional images skip-history)
   "Submit MESSAGE (a plain string) to the current session.

--- a/scripts/check-lisp.el
+++ b/scripts/check-lisp.el
@@ -29,7 +29,8 @@
   '("dsh-emacs.el" "dsh-emacs-protocol.el" "dsh-emacs-session.el"
     "dsh-emacs-markdown.el" "dsh-emacs-render.el" "dsh-emacs-events.el"
     "dsh-emacs-ui.el" "dsh-emacs-faces.el" "dsh-emacs-tokens.el"
-    "dsh-emacs-modeline.el" "dsh-emacs-server.el" "dsh-emacs-command.el"
+    "dsh-emacs-modeline.el" "dsh-emacs-queue.el" "dsh-emacs-server.el"
+    "dsh-emacs-command.el"
     "test/dsh-test.el" "test/dsh-e2e.el" "test/check-lisp-test.el")
   "默认检查的 elisp 文件（相对仓库根目录）。")
 

--- a/test/dsh-test.el
+++ b/test/dsh-test.el
@@ -3986,7 +3986,7 @@ FAIL instead of silently vanishing from the summary.  Empty CONDITIONS
                        (funcall cb t nil)))
                     ((symbol-function 'dsh-emacs--ml-busy-set)
                      (lambda (&rest _) nil)))
-            (dsh-emacs--interrupt-turn))
+            (dsh-emacs-interrupt-turn))
           (when (and sent
                      (equal (list "session.cancel" "sess-a") (car sent)))
             (dsh-test-pass "interrupt-in-inactive-buffer-targets-own-session")))
@@ -7665,6 +7665,821 @@ candidates as the UI would via `all-completions', not by destructuring."
     ;; workspace 名打进过滤器匹配不到任何候选
     (null (all-completions "WS1" table))
     (null (all-completions "Workspace" table))))
+;;; ---------------------------------------------------------------------------
+;;; 队列/引导（session/queue）：协议转换、镜像 diff、管理辅助
+;;; ---------------------------------------------------------------------------
+
+(defun dsh-emacs-test--queue-item (id placement text &optional kind)
+  "Build one wire-shaped `session/queue' frame item for tests."
+  (list (cons 'id id)
+        (cons 'placement placement)
+        (cons 'message (list (cons 'id id)
+                             (cons 'role "user")
+                             (cons 'content
+                                   (if text
+                                       (vector (list (cons 'type "text")
+                                                     (cons 'text text)))
+                                     []))
+                             (cons 'source (list (cons 'kind
+                                                       (or kind "user"))))))))
+
+;; 协议层：wire alist → struct（字段名只在构造器里出现）
+(let ((item (dsh-protocol-queue-item--from-alist
+             (dsh-emacs-test--queue-item "m1" "steering" "fix the bug"))))
+  (dsh-test-assert "queue-protocol-item-extracts-fields"
+    (equal "m1" (dsh-protocol-queue-item-id item))
+    (eq 'steering (dsh-protocol-queue-item-placement item))
+    (equal "fix the bug" (dsh-protocol-queue-item-text item))
+    (equal "user" (dsh-protocol-queue-item-kind item))))
+
+;; 协议层：帧 value（items 为 vector）→ struct 列表；缺 items 时安全为空
+(let ((items (dsh-protocol-queue-items-from-alist
+              (list (cons 'items
+                          (vector (dsh-emacs-test--queue-item
+                                   "a" "queued" "first")
+                                  (dsh-emacs-test--queue-item
+                                   "b" "context" nil "system-summary")))))))
+  (dsh-test-assert "queue-protocol-frame-value-normalized"
+    (= 2 (length items))
+    (equal "first" (dsh-protocol-queue-item-text (nth 0 items)))
+    (eq 'context (dsh-protocol-queue-item-placement (nth 1 items))))
+  (dsh-test-assert "queue-protocol-frame-value-missing-items-empty"
+    (null (dsh-protocol-queue-items-from-alist nil))
+    (null (dsh-protocol-queue-items-from-alist '((other . 1))))))
+
+;; 计数：context placement 不进 Q/S 口径（对齐 dsh web QueueDock）
+(dsh-test-assert "queue-counts-ignores-context"
+  (equal '(2 . 1)
+         (dsh-emacs-queue--counts-of
+          (list (dsh-protocol-queue-item--from-alist
+                 (dsh-emacs-test--queue-item "1" "queued" "a"))
+                (dsh-protocol-queue-item--from-alist
+                 (dsh-emacs-test--queue-item "2" "queued" "b"))
+                (dsh-protocol-queue-item--from-alist
+                 (dsh-emacs-test--queue-item "3" "steering" "c"))
+                (dsh-protocol-queue-item--from-alist
+                 (dsh-emacs-test--queue-item "4" "context" "d"))))))
+
+;; 预览：取首行、超长截断
+(dsh-test-assert "queue-preview-first-line-and-truncation"
+  (equal "one" (dsh-emacs-queue-preview "one\ntwo"))
+  (equal "abcdefghij" (dsh-emacs-queue-preview "abcdefghij"))
+  (equal 40 (length (dsh-emacs-queue-preview
+                     (make-string 100 ?x))))
+  (string-suffix-p "..." (dsh-emacs-queue-preview (make-string 100 ?x))))
+
+;; diff：消费（消失）、新排队、新引导、提升
+(let* ((old (list (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "keep" "queued" "kept"))
+                  (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "gone" "queued" "consumed one")))
+                 )
+       (new (list (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "keep" "queued" "kept"))
+                  (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "newq" "queued" "lined up"))
+                  (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "news" "steering" "steered in"))))
+       (events (dsh-emacs-queue--diff-events old new nil)))
+  (dsh-test-assert "queue-diff-events-consume-queue-steer"
+    (member (cons 'running "consumed one") events)
+    (member (cons 'queued "lined up") events)
+    (member (cons 'steering "steered in") events)
+    (= 3 (length events))))
+
+;; diff：本端删除的 id 不产生 running 反馈（删除被确认≠消费）
+(let* ((item (dsh-protocol-queue-item--from-alist
+              (dsh-emacs-test--queue-item "del" "queued" "deleted one")))
+       (events (dsh-emacs-queue--diff-events (list item) nil '("del"))))
+  (dsh-test-assert "queue-diff-events-suppresses-deleted"
+    (null events))
+  (dsh-test-assert "queue-diff-events-foreign-disappearance-is-consumption"
+    (equal '((running . "deleted one"))
+           (dsh-emacs-queue--diff-events (list item) nil nil))))
+
+;; diff：queued→steering 提升（另一端发起）报 steering
+(let* ((old (list (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "p" "queued" "promoted"))))
+       (new (list (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "p" "steering" "promoted"))))
+       (events (dsh-emacs-queue--diff-events old new nil)))
+  (dsh-test-assert "queue-diff-events-promotion-is-steering"
+    (equal '((steering . "promoted")) events)))
+
+;; 帧应用：连接首帧静默播种（不回放历史反馈），后续帧更新镜像
+(let ((buf (get-buffer-create " *t-queue-apply*")))
+  (unwind-protect
+      (progn
+        (with-current-buffer buf
+          (dsh-emacs-mode)
+          (dsh-emacs-queue-apply buf 'proc-1
+                                 (list (cons 'items
+                                             (vector (dsh-emacs-test--queue-item
+                                                      "s1" "queued" "seeded")))))
+          (dsh-test-assert "queue-apply-seeds-first-frame-silently"
+            (= 1 (length dsh-emacs--queue-items))
+            (equal "seeded" (dsh-protocol-queue-item-text
+                             (car dsh-emacs--queue-items))))
+          ;; 同一连接的第二帧：镜像全量替换
+          (dsh-emacs-queue-apply buf 'proc-1
+                                 (list (cons 'items
+                                             (vector (dsh-emacs-test--queue-item
+                                                      "s1" "queued" "seeded")
+                                                     (dsh-emacs-test--queue-item
+                                                      "s2" "steering" "added")))))
+          (dsh-test-assert "queue-apply-replaces-mirror"
+            (= 2 (length dsh-emacs--queue-items))
+            (eq 'steering (dsh-protocol-queue-item-placement
+                           (cadr dsh-emacs--queue-items))))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 事件分发级：mux 的 session/queue 帧（payload 带 items 数组）按
+;; buffer-local 会话路由到本缓冲的 dsh-emacs-queue-apply——镜像与 [next]
+;; 前缀即时更新；其它会话的帧被网关过滤，不碰镜像。
+(let ((chat (get-buffer-create " *t-queue-dispatch*"))
+      (proc (make-pipe-process :name "t-queue-proc" :buffer nil))
+      (paints nil))
+  (unwind-protect
+      (progn
+        (process-put proc 'dsh-emacs-chat-buffer chat)
+        (with-current-buffer chat
+          (dsh-emacs-mode)
+          (setq-local dsh-emacs--buffer-session "sess-q")
+          (cl-letf (((symbol-function 'run-at-time)
+                     (lambda (_delay _repeat fn) (push fn paints) t)))
+            ;; 匹配会话的帧 → 路由到 queue-apply；突发结束重绘一次后前缀可见
+            (let ((item (dsh-emacs-test--queue-item "q1" "queued" "dispatched")))
+              (dsh-emacs-events--dispatch-json
+               proc
+               (json-encode
+                (list (cons 'payload
+                            (list (cons 'type "session/queue")
+                                  (cons 'sessionId "sess-q")
+                                  (cons 'items (vector item)))))))
+              (funcall (car paints))
+              (setq paints nil))
+            (dsh-test-assert "queue-frame-dispatch-routes-to-chat"
+              (= 1 (length dsh-emacs--queue-items))
+              (equal "dispatched"
+                     (dsh-protocol-queue-item-text (car dsh-emacs--queue-items)))
+              dsh-emacs--queue-prefix)
+            ;; 其它会话的帧 → 网关过滤，镜像与前缀原样
+            (dsh-emacs-events--dispatch-json
+             proc
+             (json-encode
+              '((payload . ((type . "session/queue")
+                            (sessionId . "sess-other")
+                            (items . []))))))
+            (dsh-test-assert "queue-frame-dispatch-filters-foreign-session"
+              (= 1 (length dsh-emacs--queue-items))
+              (equal "dispatched"
+                     (dsh-protocol-queue-item-text (car dsh-emacs--queue-items)))
+              dsh-emacs--queue-prefix))))
+    (when (buffer-live-p chat) (kill-buffer chat))
+    (when (process-live-p proc) (delete-process proc))))
+
+;; 模式行指示器：空队列隐藏，非空显示 [Qn Sm]，context 不计
+(let ((buf (get-buffer-create " *t-queue-indicator*")))
+  (unwind-protect
+      (progn
+        (with-current-buffer buf
+          (dsh-emacs-mode)
+          (dsh-test-assert "queue-indicator-hidden-when-empty"
+            (string-empty-p (dsh-emacs-modeline--queue-indicator)))
+          (setq dsh-emacs--queue-items
+                (list (dsh-protocol-queue-item--from-alist
+                       (dsh-emacs-test--queue-item "1" "queued" "a"))
+                      (dsh-protocol-queue-item--from-alist
+                       (dsh-emacs-test--queue-item "2" "queued" "b"))
+                      (dsh-protocol-queue-item--from-alist
+                       (dsh-emacs-test--queue-item "3" "steering" "c"))))
+          (let ((ind (dsh-emacs-modeline--queue-indicator)))
+            (dsh-test-assert "queue-indicator-shows-counts"
+              (string-match-p "\\[Q2 S1\\]" ind)
+              (eq 'dsh-emacs-modeline-queue-face
+                  (get-text-property 0 'face ind)))))
+        ;; 非 dsh 缓冲不碰 mode line
+        (with-temp-buffer
+          (dsh-test-assert "queue-indicator-outside-chat-empty"
+            (string-empty-p (dsh-emacs-modeline--queue-indicator)))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; next 预览 = 宿主实际发送顺序的下一条：在途 steering（next-step，注入到
+;; 正在跑的 agent 下一次 step）优先于 queued（next-turn）；context 是宿主
+;; 注入内容、永不预览。即"steer 哪条，next 就显示哪条（当它成为 next-step）"
+(let* ((steer-two (mapcar (lambda (x) (dsh-protocol-queue-item--from-alist x))
+                          (list (dsh-emacs-test--queue-item "a" "steering" "Alpha")
+                                (dsh-emacs-test--queue-item "c" "steering" "Charlie")
+                                (dsh-emacs-test--queue-item "b" "queued" "Beta"))))
+       (mixed (list (dsh-protocol-queue-item--from-alist
+                     (dsh-emacs-test--queue-item "a" "steering" "Alpha"))
+                    (dsh-protocol-queue-item--from-alist
+                     (dsh-emacs-test--queue-item "b" "queued" "Beta"))))
+       (queued-only (list (dsh-protocol-queue-item--from-alist
+                           (dsh-emacs-test--queue-item "b" "queued" "Beta"))))
+       (context-first (list (dsh-protocol-queue-item--from-alist
+                             (dsh-emacs-test--queue-item "x" "context" "X"))
+                            (dsh-protocol-queue-item--from-alist
+                             (dsh-emacs-test--queue-item "b" "queued" "Beta"))
+                            (dsh-protocol-queue-item--from-alist
+                             (dsh-emacs-test--queue-item "a" "steering" "Alpha")))))
+  (let ((dsh-emacs--queue-items steer-two))
+    (dsh-test-assert "queue-next-item-steering-led"
+      (equal "Alpha" (dsh-protocol-queue-item-text
+                      (dsh-emacs-queue--next-item)))))
+  (let ((dsh-emacs--queue-items mixed))
+    (dsh-test-assert "queue-next-item-steering-over-queued"
+      (equal "Alpha" (dsh-protocol-queue-item-text
+                      (dsh-emacs-queue--next-item)))))
+  (let ((dsh-emacs--queue-items queued-only))
+    (dsh-test-assert "queue-next-item-falls-back-to-queued"
+      (equal "Beta" (dsh-protocol-queue-item-text
+                     (dsh-emacs-queue--next-item)))))
+  (let ((dsh-emacs--queue-items context-first))
+    (dsh-test-assert "queue-next-item-skips-context"
+      (equal "Alpha" (dsh-protocol-queue-item-text
+                      (dsh-emacs-queue--next-item)))))
+  (let ((dsh-emacs--queue-items nil))
+    (dsh-test-assert "queue-next-item-empty-nil"
+      (null (dsh-emacs-queue--next-item)))))
+
+;; 前缀构建：SVG 图标路径（icon + 空格 + 文本，display 属性保留、整串带
+;; prompt face）与无 SVG 回退（[next: …]）；两者都保持"整串共享 prompt
+;; face"的合并 run 不变式（anchor 扫描 / 字节级删除依赖它）
+(let ((icon (propertize " " 'display '(image :type svg :data "x"))))
+  (cl-letf (((symbol-function 'dsh-emacs-queue--next-icon) (lambda () icon)))
+    (let ((prefix (dsh-emacs-queue--prefix "Alpha")))
+      (dsh-test-assert "queue-prefix-icon-shape"
+        (string= "  Alpha " (substring-no-properties prefix))
+        (equal '(image :type svg :data "x")
+               (get-text-property 0 'display prefix))
+        (eq 'dsh-emacs-input-prompt-face
+            (get-text-property 0 'face prefix))
+        (eq 'dsh-emacs-input-prompt-face
+            (get-text-property (- (length prefix) 2) 'face prefix)))))
+  (cl-letf (((symbol-function 'dsh-emacs-queue--next-icon) (lambda () nil)))
+    (let ((prefix (dsh-emacs-queue--prefix "Alpha")))
+      (dsh-test-assert "queue-prefix-bracket-fallback"
+        (string= "[next: Alpha] " (substring-no-properties prefix))
+        (eq 'dsh-emacs-input-prompt-face
+            (get-text-property 0 'face prefix))))))
+
+;; 集成回归：steer 一条后，服务器先推 remove 帧（镜像清空）、再推 next-step
+;; 帧（条目以 steering 回归）——按宿主发送顺序，在途 steering 就是下一条，
+;; 所以 reinsert 后 next 预览显示该条目。前缀重绘按帧突发合并（run-at-time
+;; 0）：remove+reinsert 打进同一突发时只画最终态，remove 造成的瞬时空窗不上屏。
+(let ((buf (get-buffer-create " *t-queue-prefix-clear*"))
+      (paints nil))
+  (unwind-protect
+      (with-current-buffer buf
+        (dsh-emacs-mode)
+        (cl-letf (((symbol-function 'run-at-time)
+                   (lambda (_delay _repeat fn) (push fn paints) t))
+                  ;; echo 自清除计时器走 run-with-timer（内部也经 run-at-time），
+                  ;; 一并接管，避免 flash 闭包混进 paints
+                  ((symbol-function 'run-with-timer)
+                   (lambda (&rest _) t)))
+          ;; 突发 1：播种帧 → 突发结束重绘一次
+          (dsh-emacs-queue-apply
+           buf 'proc
+           (list (cons 'items
+                       (vector (dsh-emacs-test--queue-item
+                                "a" "queued" "Alpha")))))
+          (funcall (car paints))
+          (setq paints nil)
+          (dsh-test-assert "queue-prefix-steer-before-shows-next"
+            (and dsh-emacs--queue-prefix
+                 (let ((plain (substring-no-properties
+                               dsh-emacs--queue-prefix)))
+                   (and (string-search "Alpha" plain)
+                        ;; SVG 可用：图标前缀以 icon(空格) 开头；否则回退括号形式
+                        (if (image-type-available-p 'svg)
+                            (string-prefix-p " " plain)
+                          (string-search "[next:" plain))))))
+          ;; 突发 2：remove 帧（镜像即时清空，前缀暂不重绘）+ steering 回归帧
+          (dsh-emacs-queue-apply buf 'proc (list (cons 'items [])))
+          (dsh-test-assert "queue-mirror-clears-on-steer-remove"
+            (null dsh-emacs--queue-items)
+            (null (dsh-emacs-queue--next-item)))
+          (dsh-emacs-queue-apply
+           buf 'proc
+           (list (cons 'items
+                       (vector (dsh-emacs-test--queue-item
+                                "a" "steering" "Alpha")))))
+          ;; 两帧合成一次重绘
+          (dsh-test-assert "queue-burst-remove-reinsert-single-paint"
+            (= 1 (length paints)))
+          (funcall (car paints))
+          (setq paints nil)
+          (dsh-test-assert "queue-prefix-steer-reinsert-shows-inflight"
+            (and dsh-emacs--queue-prefix
+                 (string-search "Alpha"
+                                (substring-no-properties
+                                 dsh-emacs--queue-prefix))))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 闪现回归：宿主 splice 一条 item 后瞬间认领（item→空两帧打进同一突发）时，
+;; [next] 前缀不得上屏——合并重绘只看突发结束后的最终镜像（空 → 无前缀）。
+;; 对照：真正停驻的条目（突发后仍在）→ 重绘后正常显示。
+(let ((buf (get-buffer-create " *t-queue-burst*"))
+      (paints nil))
+  (unwind-protect
+      (with-current-buffer buf
+        (dsh-emacs-mode)
+        (setq-local dsh-emacs--buffer-session "sess-burst")
+        (cl-letf (((symbol-function 'run-at-time)
+                   (lambda (_delay _repeat fn) (push fn paints) t))
+                  ((symbol-function 'run-with-timer)
+                   (lambda (&rest _) t)))
+          ;; 同一突发：入队帧 + 认领帧
+          (dsh-emacs-queue-apply
+           buf 'proc
+           (list (cons 'items
+                       (vector (dsh-emacs-test--queue-item
+                                "b1" "queued" "bursty")))))
+          (dsh-emacs-queue-apply buf 'proc (list (cons 'items [])))
+          (dsh-test-assert "queue-burst-transient-single-paint-scheduled"
+            (= 1 (length paints)))
+          (funcall (car paints))
+          (setq paints nil)
+          (dsh-test-assert "queue-burst-claimed-item-never-paints"
+            (null dsh-emacs--queue-prefix)
+            (null dsh-emacs--queue-items))
+          ;; 对照：条目真实停驻（突发后仍在）→ 重绘后前缀显示
+          (dsh-emacs-queue-apply
+           buf 'proc
+           (list (cons 'items
+                       (vector (dsh-emacs-test--queue-item
+                                "b2" "queued" "parked")))))
+          (funcall (car paints))
+          (setq paints nil)
+          (dsh-test-assert "queue-burst-parked-item-paints"
+            (and dsh-emacs--queue-prefix
+                 (string-search "parked"
+                                (substring-no-properties
+                                 dsh-emacs--queue-prefix))))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 挂起提交：mode 解析（显式 / behavior 回退）与 payload mode 字段
+(let ((buf (get-buffer-create " *t-queue-deferred*"))
+      (calls nil))
+  (unwind-protect
+      (progn
+        (with-current-buffer buf
+          (setq-local dsh-emacs--buffer-session "sess-q")
+          (setq dsh-emacs--input-marker nil))
+        (let ((dsh-emacs-busy-enter-behavior 'queue))
+          (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                     (lambda (method params _cb)
+                       (push (list method params) calls))))
+            ;; 显式 steer
+            (with-current-buffer buf
+              (dsh-emacs--submit-deferred "redirect now" nil 'steer))
+            ;; behavior=queue 回退
+            (with-current-buffer buf
+              (dsh-emacs--submit-deferred "line up" nil nil))
+            (let ((dsh-emacs-busy-enter-behavior 'steer))
+              (with-current-buffer buf
+                (dsh-emacs--submit-deferred "wake up" nil nil)))
+            (dsh-test-assert "queue-deferred-mode-resolution"
+              (= 3 (length calls))
+              (equal "session.prompt" (car (nth 2 calls)))
+              (equal "steer" (cdr (assq 'mode (cadr (nth 2 calls)))))
+              (equal "queue" (cdr (assq 'mode (cadr (nth 1 calls)))))
+              (equal "steer" (cdr (assq 'mode (cadr (nth 0 calls))))))
+            (dsh-test-assert "queue-deferred-payload-shape"
+              (equal "sess-q" (cdr (assq 'sessionId (cadr (nth 0 calls)))))
+              (equal "wake up"
+                     (cdr (assq 'text
+                                (aref (cdr (assq 'content (cadr (nth 0 calls)))) 0))))))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; C-c C-c 分派：busy + behavior 语义（stop=中断、空输入=中断、queue/steer=挂起提交）
+(let ((buf (get-buffer-create " *t-send-or-stop*"))
+      (interrupted nil)
+      (submitted nil))
+  (unwind-protect
+      (let ((dsh-emacs-busy-enter-behavior 'queue))
+        (cl-letf (((symbol-function 'dsh-emacs-server-ensure) #'ignore)
+                  ((symbol-function 'dsh-emacs--busy-p) (lambda (&rest _) t))
+                  ((symbol-function 'dsh-emacs--get-input)
+                   (lambda (&rest _) "the next thing"))
+                  ((symbol-function 'dsh-emacs-interrupt-turn)
+                   (lambda (&rest _) (setq interrupted t)))
+                  ((symbol-function 'dsh-emacs--submit-prompt)
+                   (lambda (message &optional images mode)
+                     (setq submitted (list message mode)))))
+          ;; busy + queue + 文本 → 挂起提交（mode queue）
+          (with-current-buffer buf
+            (dsh-emacs-send-or-stop))
+          (dsh-test-assert "send-or-stop-busy-queue-submits"
+            (null interrupted)
+            (equal '("the next thing" queue) submitted))
+          ;; C-u 翻转 queue → steer
+          (setq submitted nil current-prefix-arg '(4))
+          (with-current-buffer buf
+            (dsh-emacs-send-or-stop))
+          (dsh-test-assert "send-or-stop-prefix-flips-to-steer"
+            (equal '("the next thing" steer) submitted))
+          ;; busy + 空输入 → 中断
+          (setq submitted nil current-prefix-arg nil)
+          (cl-letf (((symbol-function 'dsh-emacs--get-input)
+                     (lambda (&rest _) "")))
+            (with-current-buffer buf
+              (dsh-emacs-send-or-stop)))
+          (dsh-test-assert "send-or-stop-busy-empty-interrupts"
+            interrupted
+            (null submitted))
+          ;; behavior=stop → 中断（字节级旧行为）
+          (setq interrupted nil submitted nil)
+          (let ((dsh-emacs-busy-enter-behavior 'stop))
+            (with-current-buffer buf
+              (dsh-emacs-send-or-stop)))
+          (dsh-test-assert "send-or-stop-stop-behavior-interrupts"
+            interrupted
+            (null submitted))
+          ;; idle → 普通提交（无 mode）
+          (setq interrupted nil submitted nil)
+          (cl-letf (((symbol-function 'dsh-emacs--busy-p) (lambda (&rest _) nil)))
+            (with-current-buffer buf
+              (dsh-emacs-send-or-stop)))
+          (dsh-test-assert "send-or-stop-idle-submits-plain"
+            (null interrupted)
+            (equal '("the next thing" nil) submitted))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; updateQueue 动作：remove/steer/edit 的 wire 形状
+(let ((buf (get-buffer-create " *t-queue-actions*"))
+      (calls nil))
+  (unwind-protect
+      (progn
+        (with-current-buffer buf
+          (setq-local dsh-emacs--buffer-session "sess-a")
+          (let ((item (dsh-protocol-queue-item--from-alist
+                       (dsh-emacs-test--queue-item "it1" "queued" "x"))))
+            (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                       (lambda (method params _cb)
+                         (push (list method params) calls))))
+              (dsh-emacs-queue--delete item)
+              (dsh-emacs-queue--steer item)
+              (dsh-emacs-queue--edit item "rewritten")
+              (let* ((ordered (nreverse (copy-sequence calls)))
+                     (actions (mapcar (lambda (call)
+                                        (cdr (assq 'action (cadr call))))
+                                      ordered)))
+                (dsh-test-assert "queue-update-wire-actions"
+                  (= 3 (length ordered))
+                  (equal "session.updateQueue" (car (car ordered)))
+                  (equal '((kind . "remove")) (nth 0 actions))
+                  (equal '((kind . "steer")) (nth 1 actions))
+                  (equal "it1" (cdr (assq 'itemId (cadr (car ordered)))))
+                  (equal "sess-a" (cdr (assq 'sessionId (cadr (car ordered)))))
+                  (equal "rewritten"
+                         (cdr (assq 'text
+                                    (aref (cdr (assq 'content (nth 2 actions))) 0)))))))))
+        ;; 删除失败的回滚：消费反馈不被吞
+        (with-current-buffer buf
+          (setq dsh-emacs--queue-deleted '("it1"))
+          (let ((item (dsh-protocol-queue-item--from-alist
+                       (dsh-emacs-test--queue-item "it1" "queued" "x"))))
+            (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                       (lambda (_method _params cb) (funcall cb nil '((code . "x"))))))
+              (dsh-emacs-queue--delete item))
+            (dsh-test-assert "queue-delete-rollback-on-error"
+              (null dsh-emacs--queue-deleted)))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 本端操作成功即乐观更新镜像：steer 立即可见（placement → steering +
+;; deleted 抑制临时 remove 帧），不等 session/queue 帧往返
+(let ((buf (get-buffer-create " *t-queue-steer-opt*")))
+  (unwind-protect
+      (with-current-buffer buf
+        (dsh-emacs-mode)
+        (setq-local dsh-emacs--buffer-session "sess-opt")
+        (setq dsh-emacs--queue-items
+              (list (dsh-protocol-queue-item--from-alist
+                     (dsh-emacs-test--queue-item "o1" "queued" "origin"))))
+        (let ((cb nil))
+          (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                     (lambda (_method _params callback) (setq cb callback))))
+            (dsh-emacs-queue--steer (car dsh-emacs--queue-items))
+            (dsh-test-assert "queue-steer-before-success-unchanged"
+              (eq 'queued (dsh-protocol-queue-item-placement
+                           (car dsh-emacs--queue-items))))
+            (funcall cb t nil)
+            (dsh-test-assert "queue-steer-success-marks-steering-optimistically"
+              (eq 'steering (dsh-protocol-queue-item-placement
+                             (car dsh-emacs--queue-items)))
+              (member "o1" dsh-emacs--queue-deleted)))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 编辑成功：镜像文本乐观替换，前缀预览立即反映新文本
+(let ((buf (get-buffer-create " *t-queue-edit-opt*")))
+  (unwind-protect
+      (with-current-buffer buf
+        (dsh-emacs-mode)
+        (setq-local dsh-emacs--buffer-session "sess-opt")
+        (setq dsh-emacs--queue-items
+              (list (dsh-protocol-queue-item--from-alist
+                     (dsh-emacs-test--queue-item "o2" "queued" "old text"))))
+        (let ((cb nil))
+          (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                     (lambda (_method _params callback) (setq cb callback))))
+            (dsh-emacs-queue--edit (car dsh-emacs--queue-items) "new text")
+            (funcall cb t nil)
+            (dsh-test-assert "queue-edit-success-updates-text-optimistically"
+              (equal "new text"
+                     (dsh-protocol-queue-item-text
+                      (car dsh-emacs--queue-items)))))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 删除成功：镜像立即移除该条目
+(let ((buf (get-buffer-create " *t-queue-delete-opt*")))
+  (unwind-protect
+      (with-current-buffer buf
+        (dsh-emacs-mode)
+        (setq-local dsh-emacs--buffer-session "sess-opt")
+        (setq dsh-emacs--queue-items
+              (list (dsh-protocol-queue-item--from-alist
+                     (dsh-emacs-test--queue-item "o3" "queued" "gone"))))
+        (let ((cb nil))
+          (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                     (lambda (_method _params callback) (setq cb callback))))
+            (dsh-emacs-queue--delete (car dsh-emacs--queue-items))
+            (funcall cb t nil)
+            (dsh-test-assert "queue-delete-success-removes-optimistically"
+              (null dsh-emacs--queue-items)))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 用户可见契约回归：steer/delete 成功即乐观刷新 [next] 前缀（不等
+;; session/queue 帧）——镜像只是必要不充分条件，直接断言输入行前缀文本变了。
+;; 按宿主发送顺序：steer 第二条 → next 立即显示被 steer 的那条（在途
+;; steering 领先 queued）；该条被消费后回落到排队首；delete 队首 → 翻到
+;; 下一项；删光 → 清空；steer 队首 → 文本保持队首（它就是下一条）。
+(let ((buf (get-buffer-create " *t-prefix-opt-steer*"))
+      (calls nil))
+  (unwind-protect
+      (with-current-buffer buf
+        (dsh-emacs-mode)
+        (setq-local dsh-emacs--buffer-session "sess-pfx")
+        (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                   (lambda (_method _params callback) (push callback calls))))
+          (dsh-emacs-queue-apply
+           buf 'proc
+           (list (cons 'items
+                       (vector (dsh-emacs-test--queue-item "p1" "queued" "First")
+                               (dsh-emacs-test--queue-item "p2" "queued" "Second")))))
+          ;; steer 第二条（非队首）：next 立即翻到被 steer 的 Second
+          (let ((item (cl-find "p2" dsh-emacs--queue-items
+                               :key (lambda (i) (dsh-protocol-queue-item-id i))
+                               :test #'string=)))
+            (dsh-emacs-queue--steer item)
+            (let ((cb (car calls))) (setq calls (cdr calls)) (funcall cb t nil)))
+          (dsh-test-assert "queue-prefix-optimistic-steer-second-flips"
+            (and dsh-emacs--queue-prefix
+                 (string-search "Second"
+                                (substring-no-properties dsh-emacs--queue-prefix))
+                 (not (string-search "First"
+                                     (substring-no-properties
+                                      dsh-emacs--queue-prefix)))))
+          ;; 该在途项被消费（删除）：next 回落到排队首 First
+          (let ((item (cl-find "p2" dsh-emacs--queue-items
+                               :key (lambda (i) (dsh-protocol-queue-item-id i))
+                               :test #'string=)))
+            (dsh-emacs-queue--delete item)
+            (let ((cb (car calls))) (setq calls (cdr calls)) (funcall cb t nil)))
+          (dsh-test-assert "queue-prefix-optimistic-steered-consumed-falls-back"
+            (and dsh-emacs--queue-prefix
+                 (string-search "First"
+                                (substring-no-properties dsh-emacs--queue-prefix))
+                 (not (string-search "Second"
+                                     (substring-no-properties
+                                      dsh-emacs--queue-prefix)))))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+(let ((buf (get-buffer-create " *t-prefix-opt-delete*"))
+      (calls nil))
+  (unwind-protect
+      (with-current-buffer buf
+        (dsh-emacs-mode)
+        (setq-local dsh-emacs--buffer-session "sess-pfx")
+        (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                   (lambda (_method _params callback) (push callback calls))))
+          (dsh-emacs-queue-apply
+           buf 'proc
+           (list (cons 'items
+                       (vector (dsh-emacs-test--queue-item "p3" "queued" "Third")
+                               (dsh-emacs-test--queue-item "p4" "queued" "Fourth")))))
+          (let ((item (cl-find "p3" dsh-emacs--queue-items
+                               :key (lambda (i) (dsh-protocol-queue-item-id i))
+                               :test #'string=)))
+            (dsh-emacs-queue--delete item)
+            (let ((cb (car calls))) (setq calls (cdr calls)) (funcall cb t nil)))
+          (dsh-test-assert "queue-prefix-optimistic-delete-first-flips"
+            (and dsh-emacs--queue-prefix
+                 (string-search "Fourth"
+                                (substring-no-properties dsh-emacs--queue-prefix))
+                 (not (string-search "Third"
+                                     (substring-no-properties
+                                      dsh-emacs--queue-prefix)))))
+          (let ((item (cl-find "p4" dsh-emacs--queue-items
+                               :key (lambda (i) (dsh-protocol-queue-item-id i))
+                               :test #'string=)))
+            (dsh-emacs-queue--delete item)
+            (let ((cb (car calls))) (setq calls (cdr calls)) (funcall cb t nil)))
+          (dsh-test-assert "queue-prefix-optimistic-delete-only-clears"
+            (null dsh-emacs--queue-prefix))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+(let ((buf (get-buffer-create " *t-prefix-opt-head*"))
+      (calls nil))
+  (unwind-protect
+      (with-current-buffer buf
+        (dsh-emacs-mode)
+        (setq-local dsh-emacs--buffer-session "sess-pfx")
+        (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                   (lambda (_method _params callback) (push callback calls))))
+          (dsh-emacs-queue-apply
+           buf 'proc
+           (list (cons 'items
+                       (vector (dsh-emacs-test--queue-item "p5" "queued" "Fifth")
+                               (dsh-emacs-test--queue-item "p6" "queued" "Sixth")))))
+          (let ((item (cl-find "p5" dsh-emacs--queue-items
+                               :key (lambda (i) (dsh-protocol-queue-item-id i))
+                               :test #'string=)))
+            (dsh-emacs-queue--steer item)
+            (let ((cb (car calls))) (setq calls (cdr calls)) (funcall cb t nil)))
+          ;; steer 队首：next 保持队首（它就是宿主下一条，只是改为在途状态）
+          (dsh-test-assert "queue-prefix-optimistic-steer-head-keeps-head"
+            (and dsh-emacs--queue-prefix
+                 (string-search "Fifth"
+                                (substring-no-properties dsh-emacs--queue-prefix))
+                 (not (string-search "Sixth"
+                                     (substring-no-properties
+                                      dsh-emacs--queue-prefix)))))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 队列管理器：任何一层 C-g 一次彻底退出（不残留、不抛错）
+(let ((buf (get-buffer-create " *t-queue-quit*"))
+      (completed nil))
+  (unwind-protect
+      (progn
+        (with-current-buffer buf
+          (dsh-emacs-mode)
+          (setq-local dsh-emacs--buffer-session "sess-q")
+          (setq dsh-emacs--queue-items
+                (list (dsh-protocol-queue-item--from-alist
+                       (dsh-emacs-test--queue-item "i1" "queued" "one")))))
+        (cl-letf (((symbol-function 'completing-read)
+                   (lambda (&rest _) (signal 'quit nil))))
+          (with-current-buffer buf
+            (condition-case nil
+                (progn (dsh-emacs-list-queue) (setq completed t))
+              ((error quit) (setq completed nil)))))
+        (dsh-test-assert "queue-manager-one-c-g-cancels"
+          completed))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 队列菜单：菜单键作用于入口解析（vertico 高亮 > 键入精确/前缀 > 队首兜底）
+(let* ((a (dsh-protocol-queue-item--from-alist
+           (dsh-emacs-test--queue-item "a" "queued" "fix the bug")))
+       (b (dsh-protocol-queue-item--from-alist
+           (dsh-emacs-test--queue-item "b" "steering" "steered now")))
+       (table (list (cons "[Q] fix the bug" a)
+                    (cons "[S] steered now" b)))
+       (dsh-emacs--queue-pick-table table))
+  (cl-letf (((symbol-function 'minibuffer-contents)
+             (lambda () "fix")))
+    (dsh-test-assert "queue-menu-item-resolves-first"
+      (equal a (dsh-emacs-queue--menu-item))))
+  (cl-letf (((symbol-function 'minibuffer-contents)
+             (lambda () "[S] steered now")))
+    (dsh-test-assert "queue-menu-item-resolves-typed"
+      (equal b (dsh-emacs-queue--menu-item))))
+  (cl-letf (((symbol-function 'minibuffer-contents)
+             (lambda () "")))
+    (dsh-test-assert "queue-menu-item-resolves-first-fallback"
+      (equal a (dsh-emacs-queue--menu-item)))))
+
+;; 队列菜单：vertico 高亮路径——直接读 vertico--index/vertico--candidates
+;;（老版本 accessor `vertico--current' 已不存在，按字符串 assoc 会失败、
+;; 掉回队首，旧实现必然翻车）。equal 忽略文本属性，候选上的 face 不影响匹配
+(let ((buf (get-buffer-create " *t-queue-vertico*")))
+  (unwind-protect
+      (with-current-buffer buf
+        (defvar vertico-mode)                     ; batch 未加载 vertico
+        (defvar-local vertico--index -1)
+        (defvar-local vertico--candidates nil)
+        (setq vertico-mode t)
+        (setq vertico--index 1)
+        (setq vertico--candidates
+              (list (propertize "[Q] fix the bug" 'face 'completions-common-part)
+                    (propertize "[S] steered now" 'face 'vertico-current)))
+        (let* ((a (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "a" "queued" "fix the bug")))
+               (b (dsh-protocol-queue-item--from-alist
+                   (dsh-emacs-test--queue-item "b" "steering" "steered now")))
+               (dsh-emacs--queue-pick-table
+                (list (cons "[Q] fix the bug" a)
+                      (cons "[S] steered now" b))))
+          (cl-letf (((symbol-function 'minibuffer-contents)
+                     (lambda () "")))
+            (dsh-test-assert "queue-menu-item-vertico-highlight-wins"
+              (equal b (dsh-emacs-queue--menu-item))))
+          (setq vertico--index 0)
+          (dsh-test-assert "queue-menu-item-vertico-index-0"
+            (equal a (dsh-emacs-queue--menu-item)))))
+    (when (buffer-live-p buf) (kill-buffer buf))))
+
+;; 队列菜单命令：动作经 run-at-time 延迟到 minibuffer 关闭后，在打开菜单的
+;; chat buffer 里执行。真实环境中 exit-minibuffer 是 (throw 'exit nil)，
+;; 命令里 exit 之后的代码永不执行——动作必须在 exit 之前安排成定时器。
+;; 测试模拟真实 throw（catch 'exit 包住命令），断言 RPC 未被内联执行、
+;; 只能经延迟的定时器触发。
+(let ((calls nil)
+      (deferred nil)
+      (chat (get-buffer-create " *t-queue-chat*"))
+      (table (list (cons "[Q] first"
+                         (dsh-protocol-queue-item--from-alist
+                          (dsh-emacs-test--queue-item "m1" "queued" "first")))
+                   (cons "[Q] second"
+                         (dsh-protocol-queue-item--from-alist
+                          (dsh-emacs-test--queue-item "m2" "queued" "second"))))))
+  (unwind-protect
+      (with-current-buffer chat
+        (setq-local dsh-emacs--buffer-session "sess-q")
+        (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                   (lambda (method params _cb)
+                     (let ((action (cdr (assq 'action params))))
+                       (push (list method
+                                   (cdr (assq 'itemId params))
+                                   (cdr (assq 'kind action)))
+                             calls))))
+                  ((symbol-function 'minibuffer-contents)
+                   (lambda () ""))
+                  ((symbol-function 'run-at-time)
+                   (lambda (_delay _repeat fn) (push fn deferred)))
+                  ((symbol-function 'minibuffer-selected-window)
+                   (lambda () (selected-window))))
+          (let ((dsh-emacs--queue-pick-table table))
+            (catch 'exit
+              (dsh-emacs-queue--menu-delete)))
+          ;; exit 已 throw：命令剩余代码被跳过，RPC 未内联执行
+          (dsh-test-assert "queue-menu-action-not-inline-after-exit"
+            (null calls))
+          ;; 动作只能经 exit 前注册的定时器触发
+          (dolist (fn (nreverse deferred)) (funcall fn))
+          (dsh-test-assert "queue-menu-delete-runs-in-chat-buffer"
+            (equal '("session.updateQueue" "m1" "remove")
+                   (car (nreverse calls))))))
+    (when (buffer-live-p chat) (kill-buffer chat))))
+
+;; x 键整队删除：同样先注册定时器再 exit，确认后逐条 RPC
+(let ((calls nil)
+      (deferred nil)
+      (chat (get-buffer-create " *t-queue-chat*"))
+      (table (list (cons "[Q] first"
+                         (dsh-protocol-queue-item--from-alist
+                          (dsh-emacs-test--queue-item "x1" "queued" "first")))
+                   (cons "[Q] second"
+                         (dsh-protocol-queue-item--from-alist
+                          (dsh-emacs-test--queue-item "x2" "queued" "second"))))))
+  (unwind-protect
+      (with-current-buffer chat
+        (setq-local dsh-emacs--buffer-session "sess-q")
+        (cl-letf (((symbol-function 'dsh-emacs--rpc-async)
+                   (lambda (method params _cb)
+                     (push (cdr (assq 'itemId params)) calls)))
+                  ((symbol-function 'y-or-n-p)
+                   (lambda (_prompt) t))
+                  ((symbol-function 'run-at-time)
+                   (lambda (_delay _repeat fn) (push fn deferred)))
+                  ((symbol-function 'minibuffer-selected-window)
+                   (lambda () (selected-window))))
+          (let ((dsh-emacs--queue-pick-table table))
+            (catch 'exit
+              (dsh-emacs-queue--menu-delete-all)))
+          (dsh-test-assert "queue-delete-all-schedules-before-exit"
+            (null calls))
+          (dolist (fn (nreverse deferred)) (funcall fn))
+          (dsh-test-assert "queue-delete-all-confirms-and-deletes-both"
+            (equal '("x1" "x2")
+                   (sort (copy-sequence calls) #'string<)))))
+    (when (buffer-live-p chat) (kill-buffer chat))))
+
+;; 队列菜单键安装：question 同构 use-local-map（拷当前 local map + 单键）
+(let ((buf (get-buffer-create " *t-queue-keymap*")))
+  (unwind-protect
+      (with-current-buffer buf
+        (use-local-map minibuffer-local-completion-map)
+        (dsh-emacs-queue--chooser-setup-hook)
+        (dsh-test-assert "queue-menu-keys-bound-via-local-map"
+          (eq (key-binding (kbd "e")) #'dsh-emacs-queue--menu-edit)
+          (eq (key-binding (kbd "s")) #'dsh-emacs-queue--menu-steer)
+          (eq (key-binding (kbd "d")) #'dsh-emacs-queue--menu-delete)
+          (eq (key-binding (kbd "x")) #'dsh-emacs-queue--menu-delete-all)
+          (eq (key-binding (kbd "RET")) #'dsh-emacs-queue--menu-send)))
+    (when (buffer-live-p buf) (kill-buffer buf))))
 (princ "\n===== 测试总结 =====\n")
 (let ((pass (cl-count-if (lambda (r) (cdr r)) dsh-test-results))
       (fail (cl-count-if (lambda (r) (not (cdr r))) dsh-test-results)))


### PR DESCRIPTION
Closes #4

## What

While a turn is running, `C-c C-c` no longer just interrupts: input is delivered per the new `dsh-emacs-busy-enter-behavior` defcustom (`queue` by default, `steer`, or `stop` for the old interrupt-only path). `C-u C-c C-c` flips queue/steer for one send; an empty input still interrupts; `C-c C-b` interrupts explicitly. The pending inbox mirrors the server's `session/queue` mux frames, so the whole feature is frame-driven — no polling, no drift.

## Interaction (Emacs-native)

- **Mode line** — `[Q2 S1]` indicator right after the spinner: hidden when empty, zero-count placements omitted, mouse-1 opens the manager, amber `dsh-emacs-modeline-queue-face`.
- **Echo area** — transient plain-text feedback on enqueue (`queued: …`), steer (`steering: …`), consumption (`running: …`), each auto-dismissing; locally-deleted ids are suppressed so our own actions are never announced as consumption.
- **`C-c C-q` manager** — a `completing-read` minibuffer list; vertico up/down highlights an item and single keys act on it directly: `e` edit, `s` steer, `d` delete, `RET` send now, `x` delete all (confirmed); one `C-g` cancels.
- **Input-prompt preview** — a small SVG clock icon (tinted with the prompt face via `currentColor` → `:foreground`, `[next: …]` brackets as fallback without librsvg) followed by the next message the host will send: the preview follows the host's delivery order, so an item steered into the running turn (next-step) leads the hint ahead of items queued for the next turn (next-turn). `context` items (host-injected content) are never counted, listed, or previewed.

## Correctness details

- Steer/delete/edit RPCs apply to the mirror **optimistically** on success — the hint and mode-line refresh instantly, without waiting for the confirming `session/queue` frame.
- Prefix repaints are **coalesced per frame burst** (one zero-delay timer paints the settled mirror), so an item the host splices and instantly claims never flashes the hint; echoed states stay frame-truthful.
- Wire shapes verified against the installed dsh 0.1.1-rc.2 RPC table: `session.prompt` `mode` field + `content` as an array of typed blocks; `session.updateQueue` with `remove`/`steer`/`edit` actions; mux `session/queue` frames.
- Protocol fields live only in `dsh-emacs-protocol.el` constructors; per-session frame routing in the events dispatcher (not gated on history loading, since the connect-time snapshot is the only way to seed the mirror).

## Verification

`scripts/verify.sh` PASS — check-lisp clean, full unit suite green (605/0), clean load silent. Queue behavior pinned by ~60 new assertions: pure `--next-item`/diff/prefix logic, frame-path and optimistic path prefix updates, burst coalescing (transient claimed items never paint), manager keys/vertico highlight/exit-minibuffer scheduling, RPC wire shapes, session/queue frame dispatch routing + foreign-session filtering.

Docs updated in the same change: README, CHANGELOG, docs/{architecture, customization, modeline}.